### PR TITLE
Fixing the order of 'get' and subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ packet device get --id [device_UUID]
 ### Get a volume
 
 ```
-packet get volume --id [volume_UUID]
+packet volume get --id [volume_UUID]
 ```
 
 ### List projects

--- a/cmd/delete_device.go
+++ b/cmd/delete_device.go
@@ -69,7 +69,7 @@ func deleteDevice(id string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("Device deletion initiated. Please check 'packet get device -i", deviceID, "' for status")
+	fmt.Println("Device deletion initiated. Please check 'packet device get -i", deviceID, "' for status")
 	return nil
 }
 

--- a/cmd/delete_volume.go
+++ b/cmd/delete_volume.go
@@ -68,7 +68,7 @@ func deleteVolume(id string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("Volume deletion initiated. Please check 'packet get volume -i", volumeID, "' for status")
+	fmt.Println("Volume deletion initiated. Please check 'packet volume get -i", volumeID, "' for status")
 	return nil
 }
 


### PR DESCRIPTION
Simple nit: the documentation and command line help needs the order of subcommands changed to match the current CLI.