### PR TITLE
Set and display version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,12 @@ ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 BINARY=packet
 VERSION=0.0.4
-BUILD=`git rev-parse HEAD`
+BUILD=`git rev-parse --short HEAD`
 PLATFORMS=darwin linux windows
 ARCHITECTURES=amd64 arm64
 
 # Setup linker flags option for build that interoperate with variable names in src code
-LDFLAGS=-ldflags "-X main.Version=${VERSION} -X main.Build=${BUILD}"
+LDFLAGS=-ldflags "-X github.com/packethost/packet-cli/cmd.Version=${VERSION} -X github.com/packethost/packet-cli/cmd.Build=${BUILD}"
 
 default: generate-docs
 	go fmt ./...
@@ -22,20 +22,20 @@ build-all:
 	$(foreach GOOS, $(PLATFORMS),\
 	$(foreach GOARCH, $(ARCHITECTURES), $(shell export GOOS=$(GOOS); export GOARCH=$(GOARCH); go build -v -o bin/$(BINARY)-$(GOOS)-$(GOARCH))))
 
-clean: 
+clean:
 	rm -rf bin/
 	find ${ROOT_DIR} -name '${BINARY}[-?][a-zA-Z0-9]*[-?][a-zA-Z0-9]*' -delete
 
 clean-docs:
-	rm -rf docs/	
+	rm -rf docs/
 
 install:
-	go install ${LDFLAGS} 
+	go install ${LDFLAGS}
 	mv ${GOPATH}/bin/packet-cli ${GOPATH}/bin/packet
 
 generate-docs: clean-docs
 	mkdir -p docs
 	GENDOCS=true go run main.go
-  
+
 test:
 	go test ./tests

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -18,7 +18,10 @@ type Cli struct {
 }
 
 // VERSION build
-const VERSION = "0.0.2"
+var (
+	Build   string = "DefaultBuild"
+	Version string = "DefaultVersion"
+)
 
 // NewCli struct
 func NewCli() *Cli {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,7 +73,7 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Path to JSON or YAML configuration file")
-	rootCmd.Version = VERSION
+	rootCmd.Version = Version + "+" + Build
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
Set the version and build information from the
make task so it is properly displayed. This fixes
`--version` from always displaying `0.0.2`