### PR TITLE
device creation does not support custom data

### DIFF
--- a/cmd/create_device.go
+++ b/cmd/create_device.go
@@ -76,6 +76,10 @@ packet device create --hostname [hostname] --plan [plan] --facility [facility_co
 			request.UserData = userdata
 		}
 
+		if customdata != "" {
+			request.CustomData = customdata
+		}
+
 		if len(tags) > 0 {
 			request.Tags = tags
 		}


### PR DESCRIPTION
I got a report from two colleagues about a customer not being able to
create a device with custom data.

It was a bug in our cli, this PR fixed it.

```
packet-cli device create -f ams1 -H test -P c1.small.x86 -o centos_7 --customdata '{"customdatatest":"heythere"}' -p $PACKET_PROJECT_ID
```