### PR TITLE
derive version at "make build" time from git tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,21 @@ K := $(foreach exec,$(EXECUTABLES),\
 
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-BINARY=packet
-VERSION=0.0.5
+PACKAGE_NAME?=github.com/packethost/packet-cli
+BINARY?=packet
+GIT_VERSION?=$(shell git log -1 --format="%h")
+VERSION?=$(GIT_VERSION)
+RELEASE_TAG?=$(shell git tag --points-at HEAD)
+ifneq (,$(RELEASE_TAG))
+VERSION:=$(RELEASE_TAG)-$(VERSION)
+endif
+
 BUILD=`git rev-parse --short HEAD`
-PLATFORMS=darwin linux windows freebsd
-ARCHITECTURES=amd64 arm64
+PLATFORMS?=darwin linux windows freebsd
+ARCHITECTURES?=amd64 arm64
 
 # Setup linker flags option for build that interoperate with variable names in src code
-LDFLAGS=-ldflags "-X github.com/packethost/packet-cli/cmd.Version=${VERSION} -X github.com/packethost/packet-cli/cmd.Build=${BUILD}"
+LDFLAGS?=-ldflags "-X $(PACKAGE_NAME)/cmd.Version=$(VERSION) -X $(PACKAGE_NAME)/cmd.Build=$(BUILD)"
 
 default: generate-docs
 	go fmt ./...

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -19,7 +19,7 @@ type Cli struct {
 
 // VERSION build
 var (
-	Version string = "0.0.7"
+	Version string = "devel"
 )
 
 // NewCli struct


### PR DESCRIPTION
This PR bakes the version used by the CLI (`packet version`) at build time using `git tag`.

When using `go get` or `go install`, the packet-cli version will be
"devel".  

When installing from build artifacts, or when running `make`, the
version will be derived from the git tag (and latest commit sha).

