### PR TITLE
add goreleaser and RELEASE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ packet
 bin/
 *.zip
 .idea/*
+.vscode

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,52 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod download
+    # you may remove this if you don't need go generate
+    - go generate ./...
+builds:
+- env:
+  - CGO_ENABLED=0
+  binary: packet
+  ldflags:
+   - -X github.com/packethost/packet-cli/cmd.Version={{.Version}}
+   - -X github.com/packethost/packet-cli/cmd.Build=${.Commit}"
+
+  goos:
+    - freebsd
+    - linux
+    - windows
+    - darwin
+  goarch:
+    - amd64
+    - arm
+    - arm64
+  goarm:
+    - 6
+    - 7
+  ignore:
+    - goos: windows
+      goarch: arm
+    - goos: windows
+      goarch: arm64
+    - goos: darwin
+      goarch: arm64
+    - goos: darwin
+      goarch: arm
+archives:
+- format: binary
+  name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+release:
+  name_template: "{{.ProjectName}}-v{{.Version}}"
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/README.md
+++ b/README.md
@@ -37,9 +37,14 @@ The [Packet CLI binaries](https://github.com/packethost/packet-cli/releases) are
 
 ## Installation
 
-Extract the appropriate Packet CLI binaries for your platform to the desired location. If the directory is not already in your `PATH` environment variable, then it will need to be added.
+Download the appropriate Packet CLI binaries for your platform to the desired location and rename it to `packet`. If the directory is not already in your `PATH` environment variable, then it will need to be added.
 
-### Linux
+### Configuring your Path
+
+<details>
+  <summary>Configure your path in Linux</summary>
+
+## Linux
 
 If you plan to run the Packet CLI in a shell on Linux and placed the binary in /home/YOUR-USER-NAME/packet-cli/, then type the following into your terminal:
 
@@ -52,10 +57,14 @@ You can view the current value of $PATH by running:
 ```
 echo $PATH
 ```
+</details>
+
+<details>
+  <summary>Configure your path in Mac OS/X</summary>
 
 ### Mac OS X
 
-If you plan to run the Packet CLI in a shell on a Mac and placed the binary in /Users/YOUR-USER-NAME/packet-cli/, then type the following into your terminal.
+If you plan to run the Packet CLI in a shell on a Mac, download the `darwin` binary and placed the it in /Users/YOUR-USER-NAME/packet-cli/, then type the following into your terminal.
 
 ```
 export PATH=$PATH:/Users/$USER/packet-cli
@@ -66,6 +75,17 @@ You can view the current value of $PATH by running:
 ```
 echo $PATH
 ```
+
+When running the downloaded binary on a Mac, you may be prompted with the following message:
+
+> "packet" cannot be opened because the developer cannot be verified
+
+The binary can be trusted by enabling "App Store and identified developers" in "System Preferences -> Security & Privacy -> General".  Any blocked apps will appear in the bottom of this window, where they can be authorized.
+
+</details>
+
+<details>
+  <summary>Configure your path in Windows</summary>
 
 ### Windows
 
@@ -81,6 +101,7 @@ The path can be viewed by running:
 ```
 echo $env:Path
 ```
+</details>
 
 ### Shell Completion
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,32 @@
+# Release Instructions
+
+These build and release instructions are intended for the maintainers and future maintainers of this project.
+
+## Preparing a new version
+
+There are no preperation steps.
+
+* the version is computed from git tags
+* The changelog is generated from git and lives outside of git
+
+## Tagging
+
+Pull the latest `master` branch and locally `git tag -s 0.0.9`.
+
+When breaking changes are introduced bump the minor or major accordingly, restting the patch version.
+
+## Releasing
+
+Install goreleaser
+
+Run:
+
+```
+export GITHUB_TOKEN=...
+goreleaser
+```
+
+This will build and push binaries for several different OS and Architecture combinations.
+
+Any special instructions or notes can be entered by editing the release notes at https://github.com/packethost/packet-cli/releases
+


### PR DESCRIPTION
I ran into difficulties creating a quick CI/CD process (https://github.com/packethost/packet-cli/issues/43#issuecomment-662232165). The inclusion of Goreleaser will help us to release faster until we have a full CI/CD pipeline.

The goreleaser configuration included in this PR is the same one that was used to create the [v0.0.8 release](https://github.com/packethost/packet-cli/releases/tag/0.0.8).

The settings chosen match the pattern used in previous tagged releases and make the process repeatable for new project maintainers.

Future iterations on the release process should seek to remove the local tagging phase, replacing it with a Github workflow (or similar CI build steps).  Goreleaser could be replaced entirely with Github workflows or be run from Github workflows.

--- 
Goreleaser also supports brew publishing, relating to https://github.com/packethost/packet-cli/issues/38



