### PR TITLE
add initial github workflow for linting and doc checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: 'ci'
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  test:
+    name: Lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.14' ]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: Restore Cache
+      uses: actions/cache@v2
+      id: cache
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go }}
+    - run: touch ~/.packet-cli.yaml
+    - name: Detect formatting and build errors
+      run: make
+      env:
+        PACKET_TOKEN: bogus
+    - name: Detect Uncommitted Docs
+      run: git diff docs


### PR DESCRIPTION
This adds an initial GitHub Workflow that verifies that go formatting and linting guidelines are met.
This also checks that any docs/ changes were included in the PR.

`make test` (or equivalent) can be added later, once the tests can run quickly without a full e2e run.