### PR TITLE
run goreleaser when tags are pushed to github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: release
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,16 +17,13 @@ When breaking changes are introduced bump the minor or major accordingly, restti
 
 ## Releasing
 
-Install goreleaser
+Push the tag to GitHub and [GitHub Workflows](.github/workflows/release.yml) and [GoReleaser](.goreleaser.yml) will do the rest.
 
-Run:
-
-```
-export GITHUB_TOKEN=...
-goreleaser
+```sh
+git push origin --tags 0.0.9
 ```
 
-This will build and push binaries for several different OS and Architecture combinations.
+This will build and release binaries for several different OS and Architecture combinations.
 
-Any special instructions or notes can be entered by editing the release notes at https://github.com/packethost/packet-cli/releases
+Any special instructions or notes should be added by editing the release notes that goreleaser publishes. These notes can be found at https://github.com/packethost/packet-cli/releases
 


### PR DESCRIPTION
This adds a GitHub Workflow that runs `goreleaser` when tags are pushed.

The last time I released packet-cli (also the first time) was https://github.com/packethost/packet-cli/releases/tag/0.0.8. I ran `goreleaser` locally, by hand.

In future releases, maintainers will need only push a tag.  We can further evolve that practice (using PR labels or comments) once we get there.

This is based on the https://github.com/packethost/docker-machine-driver-packet/tree/master/.github/workflows/release.yml that I introduced earlier today which was used in the https://github.com/packethost/docker-machine-driver-packet/releases/tag/v0.3.0 release.

Part of #43