### PR TITLE
Add --include and --exclude and override defaults based on output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,34 @@ Flags:
 Use "packet [command] --help" for more information about a command.
 ```
 
+## Includes and Excludes
+
+Packet API resource responses may have related resources. These related
+resources can be embedded in the result or referred. Referred resources will
+only include a `Href` value, which includes the unique ID of the resource.
+Embedded resources will be represented with their full API value, which may
+contain additional embedded or referred resources.
+
+The resources that you want embedded can be _included_ in results using
+`--include`.  The resources that you want referred can be _excluded_ with
+`--exclude`.  By excluding some of the embedded-by-default resources, you can
+speed up and reduce the size of responses.  By including referred-by-default
+resources, you can avoid the round trip of subsequent calls.
+
+```sh
+packet devices get --project-id $ID --yaml --exclude=ssh_keys,plan --include=project
+```
+
+These arguments are available in any command that returns a response document.
+The included and excluded fields requested from the API may differ based on the
+output format, for example, for historic reasons, `packet projects get --yaml`
+includes the details of all project members. In the table output format, no
+member related fields are displayed and so `packet projects get` will exclude
+the member resource.
+
+Excluding fields needed for the table output will result in an error. Mixing
+includes and excludes affecting the same top-level field is not supported.
+
 ## Reference
 
 The full CLI documentation can be found [here](docs/packet.md) or by clicking the links below.

--- a/cmd/check_capacity.go
+++ b/cmd/check_capacity.go
@@ -70,6 +70,4 @@ func init() {
 	_ = checkCapacityCommand.MarkFlagRequired("facility")
 	_ = checkCapacityCommand.MarkFlagRequired("plan")
 	_ = checkCapacityCommand.MarkFlagRequired("quantity")
-	checkCapacityCommand.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	checkCapacityCommand.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/create_device.go
+++ b/cmd/create_device.go
@@ -151,6 +151,4 @@ func init() {
 	createDeviceCmd.Flags().BoolVarP(&spotInstance, "spot-instance", "I", false, `Set the device as a spot instance`)
 	createDeviceCmd.Flags().Float64VarP(&spotPriceMax, "spot-price-max", "m", 0, `--spot-price-max=1.2 or -m=1.2`)
 	createDeviceCmd.Flags().StringVarP(&terminationTime, "termination-time", "T", "", `Device termination time: --termination-time="15:04:05"`)
-	createDeviceCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	createDeviceCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/create_organization.go
+++ b/cmd/create_organization.go
@@ -80,6 +80,4 @@ func init() {
 	createOrganizationCmd.Flags().StringVarP(&logo, "logo", "l", "", "Logo URL]")
 
 	_ = createOrganizationCmd.MarkFlagRequired("name")
-	createOrganizationCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	createOrganizationCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/create_project.go
+++ b/cmd/create_project.go
@@ -72,6 +72,4 @@ func init() {
 	createProjectCmd.Flags().StringVarP(&paymentMethodID, "payment-method-id", "m", "", "UUID of the payment method")
 
 	_ = createProjectCmd.MarkFlagRequired("name")
-	createProjectCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	createProjectCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/create_ssh-key.go
+++ b/cmd/create_ssh-key.go
@@ -65,6 +65,4 @@ func init() {
 
 	_ = createSSHKeyCmd.MarkFlagRequired("label")
 	_ = createSSHKeyCmd.MarkFlagRequired("key")
-	createSSHKeyCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	createSSHKeyCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/create_virtual_network.go
+++ b/cmd/create_virtual_network.go
@@ -68,6 +68,4 @@ func init() {
 
 	_ = createVirtualNetworkCmd.MarkFlagRequired("project-id")
 	_ = createVirtualNetworkCmd.MarkFlagRequired("facility")
-	createVirtualNetworkCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	createVirtualNetworkCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/create_volume.go
+++ b/cmd/create_volume.go
@@ -83,6 +83,4 @@ func init() {
 	createVolumeCmd.Flags().StringVarP(&billingCycle, "billing-cycle", "b", "hourly", "Billing cycle")
 	createVolumeCmd.Flags().StringVarP(&description, "description", "d", "", "Description of the volume")
 	createVolumeCmd.Flags().BoolVarP(&locked, "locked", "l", false, "Set the volume to be locked")
-	createVolumeCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	createVolumeCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/retrieve_capacity.go
+++ b/cmd/retrieve_capacity.go
@@ -57,6 +57,4 @@ packet capacity get
 
 func init() {
 	capacityCmd.AddCommand(retrieveCapacityCmd)
-	retrieveCapacityCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	retrieveCapacityCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/retrieve_device.go
+++ b/cmd/retrieve_device.go
@@ -77,6 +77,4 @@ packet device get --id [device_UUID]
 func init() {
 	retriveDeviceCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project")
 	retriveDeviceCmd.Flags().StringVarP(&deviceID, "id", "i", "", "UUID of the device")
-	retriveDeviceCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	retriveDeviceCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/retrieve_device.go
+++ b/cmd/retrieve_device.go
@@ -46,7 +46,7 @@ packet device get --id [device_UUID]
 		} else if deviceID == "" && projectID == "" {
 			return fmt.Errorf("Either id or project-id should be set.")
 		} else if projectID != "" {
-			devices, _, err := PacknGo.Devices.List(projectID, nil)
+			devices, _, err := PacknGo.Devices.List(projectID, listOptions(nil, nil))
 			if err != nil {
 				return errors.Wrap(err, "Could not list Devices")
 			}

--- a/cmd/retrieve_event.go
+++ b/cmd/retrieve_event.go
@@ -109,7 +109,4 @@ func init() {
 	retrieveEventCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project")
 	retrieveEventCmd.Flags().StringVarP(&deviceID, "device-id", "d", "", "UUID of the device")
 	retrieveEventCmd.Flags().StringVarP(&volumeID, "organization-id", "o", "", "UUID of the organization")
-
-	retrieveEventCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	retrieveEventCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/retrieve_event.go
+++ b/cmd/retrieve_event.go
@@ -52,12 +52,21 @@ packet event get -d [device_UUID]
 
 Retrieve all events of a current user:
 packet event get
+
+When using "--json" or "--yaml", "--include=relationships" is implied.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var events []packngo.Event
 		var err error
 		header := []string{"ID", "Body", "Type", "Created"}
-		listOpt := &packngo.ListOptions{Includes: []string{"relationships"}}
+
+		inc := []string{"relationships"}
+
+		// don't fetch extra details that won't be rendered
+		if !isYaml && !isJSON {
+			inc = nil
+		}
+		listOpt := listOptions(inc, nil)
 
 		if deviceID != "" && projectID != "" && organizationID != "" && eventID != "" {
 			return fmt.Errorf("The id, project-id, device-id, and organization-id parameters are mutually exclusive")

--- a/cmd/retrieve_facilities.go
+++ b/cmd/retrieve_facilities.go
@@ -51,8 +51,3 @@ packet facilities get
 		return output(facilities, header, &data)
 	},
 }
-
-func init() {
-	retrieveFacilitiesCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "-j or --json JSON output")
-	retrieveFacilitiesCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "-y or --yaml YAML output")
-}

--- a/cmd/retrieve_facilities.go
+++ b/cmd/retrieve_facilities.go
@@ -37,7 +37,7 @@ packet facilities get
 	
 	`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		facilities, _, err := PacknGo.Facilities.List(nil)
+		facilities, _, err := PacknGo.Facilities.List(listOptions(nil, nil))
 		if err != nil {
 			return errors.Wrap(err, "Could not list Facilities")
 		}

--- a/cmd/retrieve_hardware_reservations.go
+++ b/cmd/retrieve_hardware_reservations.go
@@ -79,6 +79,4 @@ func init() {
 	hardwareReservationsCmd.AddCommand(retrieveHardwareReservationsCmd)
 	retrieveHardwareReservationsCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project")
 	retrieveHardwareReservationsCmd.Flags().StringVarP(&hardwareReservationID, "id", "i", "", "UUID of the hardware reservation")
-	retrieveHardwareReservationsCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	retrieveHardwareReservationsCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/retrieve_hardware_reservations.go
+++ b/cmd/retrieve_hardware_reservations.go
@@ -36,10 +36,19 @@ var retrieveHardwareReservationsCmd = &cobra.Command{
 
 Retrieve all hardware reservations of a project:
 packet hardware_reservations get -p [project_id]
+
+When using "--json" or "--yaml", "--include=project,facility,device" is implied.
 	`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		header := []string{"ID", "Facility", "Plan", "Created"}
-		listOpt := &packngo.ListOptions{Includes: []string{"project,facility,device"}}
+
+		inc := []string{"project", "facility", "device"}
+
+		// don't fetch extra details that won't be rendered
+		if !isYaml && !isJSON {
+			inc = nil
+		}
+		listOpt := listOptions(inc, nil)
 
 		if hardwareReservationID == "" && projectID == "" {
 			return fmt.Errorf("Either id or project-id should be set.")
@@ -59,8 +68,8 @@ packet hardware_reservations get -p [project_id]
 
 			return output(reservations, header, &data)
 		} else if hardwareReservationID != "" {
-			getOpt := &packngo.GetOptions{Includes: listOpt.Includes}
-			r, _, err := PacknGo.HardwareReservations.Get(hardwareReservationID, getOpt)
+			getOpts := &packngo.GetOptions{Includes: listOpt.Includes, Excludes: listOpt.Excludes}
+			r, _, err := PacknGo.HardwareReservations.Get(hardwareReservationID, getOpts)
 			if err != nil {
 				return errors.Wrap(err, "Could not get Hardware Reservation")
 			}

--- a/cmd/retrieve_ip.go
+++ b/cmd/retrieve_ip.go
@@ -106,7 +106,4 @@ func init() {
 	retrieveIPCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project")
 	retrieveIPCmd.Flags().StringVarP(&assignmentID, "assignment-id", "a", "", "UUID of the assignment")
 	retrieveIPCmd.Flags().StringVarP(&reservationID, "reservation-id", "r", "", "UUID of the reservation")
-
-	retrieveIPCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	retrieveIPCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/retrieve_operating_system.go
+++ b/cmd/retrieve_operating_system.go
@@ -47,8 +47,3 @@ var retrieveOperatingSystemCmd = &cobra.Command{
 		return output(oss, header, &data)
 	},
 }
-
-func init() {
-	retrieveOperatingSystemCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	retrieveOperatingSystemCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
-}

--- a/cmd/retrieve_organization.go
+++ b/cmd/retrieve_organization.go
@@ -21,6 +21,7 @@
 package cmd
 
 import (
+	"github.com/packethost/packngo"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -39,8 +40,9 @@ packet organization get -i [organization-id]
 
 	`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		listOpts := listOptions(nil, nil)
 		if organizationID == "" {
-			orgs, _, err := PacknGo.Organizations.List(nil)
+			orgs, _, err := PacknGo.Organizations.List(listOpts)
 			if err != nil {
 				return errors.Wrap(err, "Could not list Organizations")
 			}
@@ -54,7 +56,8 @@ packet organization get -i [organization-id]
 
 			return output(orgs, header, &data)
 		} else {
-			org, _, err := PacknGo.Organizations.Get(organizationID, nil)
+			getOpts := &packngo.GetOptions{Includes: listOpts.Includes, Excludes: listOpts.Excludes}
+			org, _, err := PacknGo.Organizations.Get(organizationID, getOpts)
 			if err != nil {
 				return errors.Wrap(err, "Could not get Organization")
 			}

--- a/cmd/retrieve_organization.go
+++ b/cmd/retrieve_organization.go
@@ -71,6 +71,4 @@ packet organization get -i [organization-id]
 
 func init() {
 	retrieveOrganizationCmd.Flags().StringVarP(&organizationID, "organization-id", "i", "", "UUID of the organization")
-	retrieveOrganizationCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	retrieveOrganizationCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/retrieve_plans.go
+++ b/cmd/retrieve_plans.go
@@ -50,8 +50,3 @@ var retrievePlansCmd = &cobra.Command{
 		return output(plans, header, &data)
 	},
 }
-
-func init() {
-	retrievePlansCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	retrievePlansCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
-}

--- a/cmd/retrieve_plans.go
+++ b/cmd/retrieve_plans.go
@@ -35,7 +35,7 @@ var retrievePlansCmd = &cobra.Command{
   
   `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		plans, _, err := PacknGo.Plans.List(nil)
+		plans, _, err := PacknGo.Plans.List(listOptions(nil, nil))
 		if err != nil {
 			return errors.Wrap(err, "Could not list Plans")
 		}

--- a/cmd/retrieve_project.go
+++ b/cmd/retrieve_project.go
@@ -94,6 +94,4 @@ packet project get -n [project_name]
 func init() {
 	retriveProjectCmd.Flags().StringVarP(&projectName, "project", "n", "", "Name of the project")
 	retriveProjectCmd.Flags().StringVarP(&projectID, "project-id", "i", "", "UUID of the project")
-	retriveProjectCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	retriveProjectCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/retrieve_ssh_key.go
+++ b/cmd/retrieve_ssh_key.go
@@ -75,6 +75,4 @@ packet ssh-key get --id [ssh-key_UUID]
 
 func init() {
 	retrieveSSHKeysCmd.Flags().StringVarP(&sshKeyID, "id", "i", "", "UUID of the SSH key")
-	retrieveSSHKeysCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	retrieveSSHKeysCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/retrieve_user.go
+++ b/cmd/retrieve_user.go
@@ -69,6 +69,4 @@ packet user get --id [user_UUID]
 
 func init() {
 	retriveUserCmd.Flags().StringVarP(&userID, "id", "i", "", "UUID of the user")
-	retriveUserCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	retriveUserCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/retrieve_virtual_network.go
+++ b/cmd/retrieve_virtual_network.go
@@ -56,6 +56,4 @@ packet virtual-network get -p [project_UUID]
 func init() {
 	retrieveVirtualNetworksCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project")
 	_ = retrieveVirtualNetworksCmd.MarkFlagRequired("project-id")
-	retrieveVirtualNetworksCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	retrieveVirtualNetworksCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/retrieve_virtual_network.go
+++ b/cmd/retrieve_virtual_network.go
@@ -37,7 +37,7 @@ packet virtual-network get -p [project_UUID]
 
 	`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		vnets, _, err := PacknGo.ProjectVirtualNetworks.List(projectID, nil)
+		vnets, _, err := PacknGo.ProjectVirtualNetworks.List(projectID, listOptions(nil, nil))
 		if err != nil {
 			return errors.Wrap(err, "Could not list Project Virtual Networks")
 		}

--- a/cmd/retrieve_volume.go
+++ b/cmd/retrieve_volume.go
@@ -51,7 +51,7 @@ packet volume get --id [volume_UUID]
 		} else if projectID == "" && volumeID == "" {
 			return fmt.Errorf("Either id or project-id should be set.")
 		} else if projectID != "" {
-			volumes, _, err := PacknGo.Volumes.List(projectID, nil)
+			volumes, _, err := PacknGo.Volumes.List(projectID, listOptions(nil, nil))
 			if err != nil {
 				return errors.Wrap(err, "Could not list Volumes")
 			}

--- a/cmd/retrieve_volume.go
+++ b/cmd/retrieve_volume.go
@@ -83,6 +83,4 @@ packet volume get --id [volume_UUID]
 func init() {
 	retriveVolumeCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project")
 	retriveVolumeCmd.Flags().StringVarP(&volumeID, "id", "i", "", "UUID of the volume")
-	retriveVolumeCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	retriveVolumeCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/retrieve_vpn.go
+++ b/cmd/retrieve_vpn.go
@@ -51,7 +51,4 @@ packet vpn get --faciliy ewr1
 func init() {
 	retrieveVpnCmd.Flags().StringVarP(&facility, "facility", "f", "", "Code of the facility for which VPN config is to be retrieved")
 	_ = retrieveVpnCmd.MarkFlagRequired("id")
-
-	retrieveVpnCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
-	retrieveVpnCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,10 @@ var (
 	isJSON      bool
 	isYaml      bool
 	packetToken string
+
+	includes *[]string // nolint:unused
+	excludes *[]string // nolint:unused
+
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -78,7 +82,27 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
 	rootCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
 
+	includes = rootCmd.PersistentFlags().StringSlice("include", nil, "Comma seperated Href references to expand in results, may be dotted three levels deep")
+	excludes = rootCmd.PersistentFlags().StringSlice("exclude", nil, "Comma seperated Href references to collapse in results, may be dotted three levels deep")
+
 	rootCmd.Version = Version
+}
+
+// listOptions creates a ListOptions using the includes and excludes persistent
+// flags. When not defined, the defaults given will be supplied.
+func listOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions {
+	listOptions := &packngo.ListOptions{
+		Includes: defaultIncludes,
+		Excludes: defaultExcludes,
+	}
+	if rootCmd.Flags().Changed("include") {
+		listOptions.Includes = *includes
+	}
+	if rootCmd.Flags().Changed("exclude") {
+		listOptions.Excludes = *excludes
+	}
+
+	return listOptions
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,6 +74,10 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Path to JSON or YAML configuration file")
+
+	rootCmd.PersistentFlags().BoolVarP(&isJSON, "json", "j", false, "JSON output")
+	rootCmd.PersistentFlags().BoolVarP(&isYaml, "yaml", "y", false, "YAML output")
+
 	rootCmd.Version = Version
 }
 

--- a/docs/packet.md
+++ b/docs/packet.md
@@ -9,8 +9,12 @@ Command line interface for Packet Host
 ### Options
 
 ```
-      --config string   Path to JSON or YAML configuration file
-  -h, --help            help for packet
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+  -h, --help              help for packet
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_2fa.md
+++ b/docs/packet_2fa.md
@@ -15,7 +15,11 @@ Two Factor Authentication operations: enable, disable, receive
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_2fa_disable.md
+++ b/docs/packet_2fa_disable.md
@@ -29,7 +29,11 @@ packet 2fa disable [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_2fa_enable.md
+++ b/docs/packet_2fa_enable.md
@@ -29,7 +29,11 @@ packet 2fa enable [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_2fa_receive.md
+++ b/docs/packet_2fa_receive.md
@@ -28,7 +28,11 @@ packet 2fa receive [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_capacity.md
+++ b/docs/packet_capacity.md
@@ -15,7 +15,11 @@ Capacities operations: get, check
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_capacity_check.md
+++ b/docs/packet_capacity_check.md
@@ -19,16 +19,18 @@ packet capacity check [flags]
 ```
   -f, --facility string   Code of the facility
   -h, --help              help for check
-  -j, --json              JSON output
   -p, --plan string       Name of the plan
   -q, --quantity int      Number of devices wanted
-  -y, --yaml              YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_capacity_get.md
+++ b/docs/packet_capacity_get.md
@@ -17,14 +17,16 @@ packet capacity get [flags]
 
 ```
   -h, --help   help for get
-  -j, --json   JSON output
-  -y, --yaml   YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_device.md
+++ b/docs/packet_device.md
@@ -15,7 +15,11 @@ Device operations: create, delete, update, start/stop, reboot and get.
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_device_create.md
+++ b/docs/packet_device_create.md
@@ -25,7 +25,6 @@ packet device create [flags]
   -h, --help                             help for create
   -H, --hostname string                  Hostname
   -i, --ipxe-script-url string           URL to the iPXE script
-  -j, --json                             JSON output
   -o, --operating-system string          Operating system name for the device
   -P, --plan string                      Name of the plan
   -p, --project-id string                UUID of the project where the device will be created
@@ -36,13 +35,16 @@ packet device create [flags]
   -t, --tags strings                     Tags for the device: --tags="tag1,tag2"
   -T, --termination-time string          Device termination time: --termination-time="15:04:05"
   -u, --userdata string                  User data
-  -y, --yaml                             YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_device_delete.md
+++ b/docs/packet_device_delete.md
@@ -25,7 +25,11 @@ packet device delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_device_get.md
+++ b/docs/packet_device_get.md
@@ -19,15 +19,17 @@ packet device get [flags]
 ```
   -h, --help                help for get
   -i, --id string           UUID of the device
-  -j, --json                JSON output
   -p, --project-id string   UUID of the project
-  -y, --yaml                YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_device_reboot.md
+++ b/docs/packet_device_reboot.md
@@ -24,7 +24,11 @@ packet device reboot [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_device_start.md
+++ b/docs/packet_device_start.md
@@ -24,7 +24,11 @@ packet device start [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_device_stop.md
+++ b/docs/packet_device_stop.md
@@ -24,7 +24,11 @@ packet device stop [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_device_update.md
+++ b/docs/packet_device_update.md
@@ -32,7 +32,11 @@ packet device update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_event.md
+++ b/docs/packet_event.md
@@ -15,7 +15,11 @@ Events operations: get
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_event_get.md
+++ b/docs/packet_event_get.md
@@ -23,6 +23,8 @@ packet event get -d [device_UUID]
 Retrieve all events of a current user:
 packet event get
 
+When using "--json" or "--yaml", "--include=relationships" is implied.
+
 
 ```
 packet event get [flags]
@@ -34,16 +36,18 @@ packet event get [flags]
   -d, --device-id string         UUID of the device
   -h, --help                     help for get
   -i, --id string                UUID of the event
-  -j, --json                     JSON output
   -o, --organization-id string   UUID of the organization
   -p, --project-id string        UUID of the project
-  -y, --yaml                     YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_facilities.md
+++ b/docs/packet_facilities.md
@@ -15,7 +15,11 @@ Facility operations: get
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_facilities_get.md
+++ b/docs/packet_facilities_get.md
@@ -18,14 +18,16 @@ packet facilities get [flags]
 
 ```
   -h, --help   help for get
-  -j, --json   -j or --json JSON output
-  -y, --yaml   -y or --yaml YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_hardware-reservation.md
+++ b/docs/packet_hardware-reservation.md
@@ -15,7 +15,11 @@ Hardware reservation operations: get, move
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_hardware-reservation_get.md
+++ b/docs/packet_hardware-reservation_get.md
@@ -8,6 +8,8 @@ Example:
 
 Retrieve all hardware reservations of a project:
 packet hardware_reservations get -p [project_id]
+
+When using "--json" or "--yaml", "--include=project,facility,device" is implied.
 	
 
 ```
@@ -19,15 +21,17 @@ packet hardware-reservation get [flags]
 ```
   -h, --help                help for get
   -i, --id string           UUID of the hardware reservation
-  -j, --json                JSON output
   -p, --project-id string   UUID of the project
-  -y, --yaml                YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_hardware-reservation_move.md
+++ b/docs/packet_hardware-reservation_move.md
@@ -24,7 +24,11 @@ packet hardware-reservation move [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_ip.md
+++ b/docs/packet_ip.md
@@ -15,7 +15,11 @@ IP address, reservations and assignment operations: assign, unassign, remove, av
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_ip_assign.md
+++ b/docs/packet_ip_assign.md
@@ -25,7 +25,11 @@ packet ip assign [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_ip_available.md
+++ b/docs/packet_ip_available.md
@@ -25,7 +25,11 @@ packet ip available [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_ip_get.md
+++ b/docs/packet_ip_get.md
@@ -29,16 +29,18 @@ packet ip get [flags]
 ```
   -a, --assignment-id string    UUID of the assignment
   -h, --help                    help for get
-  -j, --json                    JSON output
   -p, --project-id string       UUID of the project
   -r, --reservation-id string   UUID of the reservation
-  -y, --yaml                    YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_ip_remove.md
+++ b/docs/packet_ip_remove.md
@@ -24,7 +24,11 @@ packet ip remove [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_ip_request.md
+++ b/docs/packet_ip_request.md
@@ -28,7 +28,11 @@ packet ip request [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_ip_unassign.md
+++ b/docs/packet_ip_unassign.md
@@ -24,7 +24,11 @@ packet ip unassign [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_operating-systems.md
+++ b/docs/packet_operating-systems.md
@@ -15,7 +15,11 @@ Operating system operations: get
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_operating-systems_get.md
+++ b/docs/packet_operating-systems_get.md
@@ -15,14 +15,16 @@ packet operating-systems get [flags]
 
 ```
   -h, --help   help for get
-  -j, --json   JSON output
-  -y, --yaml   YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_organization.md
+++ b/docs/packet_organization.md
@@ -15,7 +15,11 @@ Organization operations: create, update, delete and get
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_organization_create.md
+++ b/docs/packet_organization_create.md
@@ -19,18 +19,20 @@ packet organization create [flags]
 ```
   -d, --description string   Description of the organization
   -h, --help                 help for create
-  -j, --json                 JSON output
   -l, --logo string          Logo URL]
   -n, --name string          Name of the organization
   -t, --twitter string       Twitter URL of the organization
   -w, --website string       Website URL of the organization
-  -y, --yaml                 YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_organization_delete.md
+++ b/docs/packet_organization_delete.md
@@ -25,7 +25,11 @@ packet organization delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_organization_get.md
+++ b/docs/packet_organization_get.md
@@ -22,15 +22,17 @@ packet organization get [flags]
 
 ```
   -h, --help                     help for get
-  -j, --json                     JSON output
   -i, --organization-id string   UUID of the organization
-  -y, --yaml                     YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_organization_get_payment-methods.md
+++ b/docs/packet_organization_get_payment-methods.md
@@ -24,9 +24,11 @@ packet organization get payment-methods [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
-  -j, --json            JSON output
-  -y, --yaml            YAML output
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_organization_update.md
+++ b/docs/packet_organization_update.md
@@ -29,7 +29,11 @@ packet organization update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_plan.md
+++ b/docs/packet_plan.md
@@ -15,7 +15,11 @@ Plan operations: get
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_plan_get.md
+++ b/docs/packet_plan_get.md
@@ -18,14 +18,16 @@ packet plan get [flags]
 
 ```
   -h, --help   help for get
-  -j, --json   JSON output
-  -y, --yaml   YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_project.md
+++ b/docs/packet_project.md
@@ -15,7 +15,11 @@ Project operations: create, delete, update and get
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_project_create.md
+++ b/docs/packet_project_create.md
@@ -18,17 +18,19 @@ packet project create [flags]
 
 ```
   -h, --help                       help for create
-  -j, --json                       JSON output
   -n, --name string                Name of the project
   -o, --organization-id string     UUID of the organization
   -m, --payment-method-id string   UUID of the payment method
-  -y, --yaml                       YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_project_delete.md
+++ b/docs/packet_project_delete.md
@@ -25,7 +25,11 @@ packet project delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_project_get.md
+++ b/docs/packet_project_get.md
@@ -12,6 +12,8 @@ packet project get
 Retrieve a specific project:
 packet project get -i [project_UUID]
 packet project get -n [project_name]
+
+When using "--json" or "--yaml", "--include=members" is implied.
 	
 
 ```
@@ -22,16 +24,18 @@ packet project get [flags]
 
 ```
   -h, --help                help for get
-  -j, --json                JSON output
   -n, --project string      Name of the project
   -i, --project-id string   UUID of the project
-  -y, --yaml                YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_project_update.md
+++ b/docs/packet_project_update.md
@@ -26,7 +26,11 @@ packet project update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_ssh-key.md
+++ b/docs/packet_ssh-key.md
@@ -15,7 +15,11 @@ SSH key operations: create, delete, update and get
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_ssh-key_create.md
+++ b/docs/packet_ssh-key_create.md
@@ -18,16 +18,18 @@ packet ssh-key create [flags]
 
 ```
   -h, --help           help for create
-  -j, --json           JSON output
   -k, --key string     Public SSH key string
   -l, --label string   Name of the SSH key
-  -y, --yaml           YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_ssh-key_delete.md
+++ b/docs/packet_ssh-key_delete.md
@@ -25,7 +25,11 @@ packet ssh-key delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_ssh-key_get.md
+++ b/docs/packet_ssh-key_get.md
@@ -23,14 +23,16 @@ packet ssh-key get [flags]
 ```
   -h, --help        help for get
   -i, --id string   UUID of the SSH key
-  -j, --json        JSON output
-  -y, --yaml        YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_ssh-key_update.md
+++ b/docs/packet_ssh-key_update.md
@@ -26,7 +26,11 @@ packet ssh-key update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_user.md
+++ b/docs/packet_user.md
@@ -15,7 +15,11 @@ User operations: get
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_user_get.md
+++ b/docs/packet_user_get.md
@@ -23,14 +23,16 @@ packet user get [flags]
 ```
   -h, --help        help for get
   -i, --id string   UUID of the user
-  -j, --json        JSON output
-  -y, --yaml        YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_virtual-network.md
+++ b/docs/packet_virtual-network.md
@@ -15,7 +15,11 @@ Virtual network operations: create, delete and get
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_virtual-network_create.md
+++ b/docs/packet_virtual-network_create.md
@@ -20,15 +20,17 @@ packet virtual-network create [flags]
   -d, --description string   Description of the virtual network
   -f, --facility string      Code of the facility
   -h, --help                 help for create
-  -j, --json                 JSON output
   -p, --project-id string    UUID of the project
-  -y, --yaml                 YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_virtual-network_delete.md
+++ b/docs/packet_virtual-network_delete.md
@@ -25,7 +25,11 @@ packet virtual-network delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_virtual-network_get.md
+++ b/docs/packet_virtual-network_get.md
@@ -18,15 +18,17 @@ packet virtual-network get [flags]
 
 ```
   -h, --help                help for get
-  -j, --json                JSON output
   -p, --project-id string   UUID of the project
-  -y, --yaml                YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_volume.md
+++ b/docs/packet_volume.md
@@ -15,7 +15,11 @@ Volume operations: create, delete, attach, detach and get
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_volume_attach.md
+++ b/docs/packet_volume_attach.md
@@ -25,7 +25,11 @@ packet volume attach [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_volume_create.md
+++ b/docs/packet_volume_create.md
@@ -21,18 +21,20 @@ packet volume create [flags]
   -d, --description string     Description of the volume
   -f, --facility string        Code of the facility where the volume will be created
   -h, --help                   help for create
-  -j, --json                   JSON output
   -l, --locked                 Set the volume to be locked
   -P, --plan string            Name of the plan
   -p, --project-id string      UUID of the project
   -s, --size int               Size in GB]
-  -y, --yaml                   YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_volume_delete.md
+++ b/docs/packet_volume_delete.md
@@ -25,7 +25,11 @@ packet volume delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_volume_detach.md
+++ b/docs/packet_volume_detach.md
@@ -24,7 +24,11 @@ packet volume detach [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_volume_get.md
+++ b/docs/packet_volume_get.md
@@ -23,15 +23,17 @@ packet volume get [flags]
 ```
   -h, --help                help for get
   -i, --id string           UUID of the volume
-  -j, --json                JSON output
   -p, --project-id string   UUID of the project
-  -y, --yaml                YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_vpn.md
+++ b/docs/packet_vpn.md
@@ -15,7 +15,11 @@ VPN service operations: enable, disable, get
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_vpn_disable.md
+++ b/docs/packet_vpn_disable.md
@@ -23,7 +23,11 @@ packet vpn disable [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_vpn_enable.md
+++ b/docs/packet_vpn_enable.md
@@ -23,7 +23,11 @@ packet vpn enable [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO

--- a/docs/packet_vpn_get.md
+++ b/docs/packet_vpn_get.md
@@ -19,14 +19,16 @@ packet vpn get [flags]
 ```
   -f, --facility string   Code of the facility for which VPN config is to be retrieved
   -h, --help              help for get
-  -j, --json              JSON output
-  -y, --yaml              YAML output
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   Path to JSON or YAML configuration file
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+  -y, --yaml              YAML output
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
* Globalizes the `--json` and `--yaml` arguments as a simplification.
* Adds `--include` and `--exclude` which can accept comma-separated values or can be given multiple times to specify more includes/excludes.  Naturally, dotted syntax (as supported by the API) can be used to include/exclude deep values.
* Default includes will not be used when their results are not rendered (affects projects, events, hardware-reservations). Do override defaults in longer listing formats, `--include=""` can be used.

Fixes #51: `packet projects get` no longer includes `members` as an include, unless `--json`/`--yaml` is provided
