### PR TITLE
fix duplicate error and always 0 exit code

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -32,12 +32,6 @@ func NewCli() *Cli {
 		return nil
 	}
 
-	err = rootCmd.Execute()
-	if err != nil {
-		fmt.Println("Execution error:", err)
-		return nil
-	}
-
 	rootCmd.DisableSuggestions = false
 	cli.MainCmd = rootCmd
 	return cli

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,15 +62,6 @@ func packetConnect(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-}
-
 func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Path to JSON or YAML configuration file")

--- a/main.go
+++ b/main.go
@@ -21,9 +21,14 @@
 package main
 
 import (
+	"os"
+
 	"github.com/packethost/packet-cli/cmd"
 )
 
 func main() {
-	cmd.NewCli()
+	cli := cmd.NewCli()
+	if err := cli.MainCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Fixes #75

(the "exit status" output is only present because this was run with `go run`)

```
$ go run main.go devices get  --project-id=12
Error: Could not list Devices: GET https://api.packet.net/projects/12/devices?include=facility: 404 Not found 
Usage:
  packet device get [flags]

Flags:
  -h, --help                help for get
  -i, --id string           UUID of the device
  -j, --json                JSON output
  -p, --project-id string   UUID of the project
  -y, --yaml                YAML output

Global Flags:
      --config string   Path to JSON or YAML configuration file

exit status 1
```