### PR TITLE
add "--search" global flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,7 +41,7 @@ var (
 
 	includes *[]string // nolint:unused
 	excludes *[]string // nolint:unused
-
+	search   string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -79,6 +79,7 @@ func init() {
 
 	includes = rootCmd.PersistentFlags().StringSlice("include", nil, "Comma seperated Href references to expand in results, may be dotted three levels deep")
 	excludes = rootCmd.PersistentFlags().StringSlice("exclude", nil, "Comma seperated Href references to collapse in results, may be dotted three levels deep")
+	rootCmd.PersistentFlags().StringVar(&search, "search", "", "Search keyword for use in 'get' actions. Search is not supported by all resources.")
 
 	rootCmd.Version = Version
 }
@@ -95,6 +96,9 @@ func listOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
 	}
 	if rootCmd.Flags().Changed("exclude") {
 		listOptions.Excludes = *excludes
+	}
+	if rootCmd.Flags().Changed("search") {
+		listOptions.Search = search
 	}
 
 	return listOptions

--- a/docs/packet.md
+++ b/docs/packet.md
@@ -14,6 +14,7 @@ Command line interface for Equinix Metal
   -h, --help              help for packet
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_2fa.md
+++ b/docs/packet_2fa.md
@@ -19,6 +19,7 @@ Two Factor Authentication operations: enable, disable, receive
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_2fa_disable.md
+++ b/docs/packet_2fa_disable.md
@@ -33,6 +33,7 @@ packet 2fa disable [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_2fa_enable.md
+++ b/docs/packet_2fa_enable.md
@@ -33,6 +33,7 @@ packet 2fa enable [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_2fa_receive.md
+++ b/docs/packet_2fa_receive.md
@@ -32,6 +32,7 @@ packet 2fa receive [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_capacity.md
+++ b/docs/packet_capacity.md
@@ -19,6 +19,7 @@ Capacities operations: get, check
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_capacity_check.md
+++ b/docs/packet_capacity_check.md
@@ -30,6 +30,7 @@ packet capacity check [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_capacity_get.md
+++ b/docs/packet_capacity_get.md
@@ -26,6 +26,7 @@ packet capacity get [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_device.md
+++ b/docs/packet_device.md
@@ -19,6 +19,7 @@ Device operations: create, delete, update, start/stop, reboot and get.
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_device_create.md
+++ b/docs/packet_device_create.md
@@ -44,6 +44,7 @@ packet device create [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_device_delete.md
+++ b/docs/packet_device_delete.md
@@ -29,6 +29,7 @@ packet device delete [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_device_get.md
+++ b/docs/packet_device_get.md
@@ -29,6 +29,7 @@ packet device get [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_device_reboot.md
+++ b/docs/packet_device_reboot.md
@@ -28,6 +28,7 @@ packet device reboot [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_device_start.md
+++ b/docs/packet_device_start.md
@@ -28,6 +28,7 @@ packet device start [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_device_stop.md
+++ b/docs/packet_device_stop.md
@@ -28,6 +28,7 @@ packet device stop [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_device_update.md
+++ b/docs/packet_device_update.md
@@ -36,6 +36,7 @@ packet device update [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_event.md
+++ b/docs/packet_event.md
@@ -19,6 +19,7 @@ Events operations: get
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_event_get.md
+++ b/docs/packet_event_get.md
@@ -47,6 +47,7 @@ packet event get [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_facilities.md
+++ b/docs/packet_facilities.md
@@ -19,6 +19,7 @@ Facility operations: get
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_facilities_get.md
+++ b/docs/packet_facilities_get.md
@@ -27,6 +27,7 @@ packet facilities get [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_hardware-reservation.md
+++ b/docs/packet_hardware-reservation.md
@@ -19,6 +19,7 @@ Hardware reservation operations: get, move
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_hardware-reservation_get.md
+++ b/docs/packet_hardware-reservation_get.md
@@ -31,6 +31,7 @@ packet hardware-reservation get [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_hardware-reservation_move.md
+++ b/docs/packet_hardware-reservation_move.md
@@ -28,6 +28,7 @@ packet hardware-reservation move [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_ip.md
+++ b/docs/packet_ip.md
@@ -19,6 +19,7 @@ IP address, reservations and assignment operations: assign, unassign, remove, av
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_ip_assign.md
+++ b/docs/packet_ip_assign.md
@@ -29,6 +29,7 @@ packet ip assign [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_ip_available.md
+++ b/docs/packet_ip_available.md
@@ -29,6 +29,7 @@ packet ip available [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_ip_get.md
+++ b/docs/packet_ip_get.md
@@ -40,6 +40,7 @@ packet ip get [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_ip_remove.md
+++ b/docs/packet_ip_remove.md
@@ -28,6 +28,7 @@ packet ip remove [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_ip_request.md
+++ b/docs/packet_ip_request.md
@@ -32,6 +32,7 @@ packet ip request [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_ip_unassign.md
+++ b/docs/packet_ip_unassign.md
@@ -28,6 +28,7 @@ packet ip unassign [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_operating-systems.md
+++ b/docs/packet_operating-systems.md
@@ -19,6 +19,7 @@ Operating system operations: get
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_operating-systems_get.md
+++ b/docs/packet_operating-systems_get.md
@@ -24,6 +24,7 @@ packet operating-systems get [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_organization.md
+++ b/docs/packet_organization.md
@@ -19,6 +19,7 @@ Organization operations: create, update, delete and get
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_organization_create.md
+++ b/docs/packet_organization_create.md
@@ -32,6 +32,7 @@ packet organization create [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_organization_delete.md
+++ b/docs/packet_organization_delete.md
@@ -29,6 +29,7 @@ packet organization delete [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_organization_get.md
+++ b/docs/packet_organization_get.md
@@ -32,6 +32,7 @@ packet organization get [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_organization_get_payment-methods.md
+++ b/docs/packet_organization_get_payment-methods.md
@@ -28,6 +28,7 @@ packet organization get payment-methods [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_organization_update.md
+++ b/docs/packet_organization_update.md
@@ -33,6 +33,7 @@ packet organization update [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_plan.md
+++ b/docs/packet_plan.md
@@ -19,6 +19,7 @@ Plan operations: get
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_plan_get.md
+++ b/docs/packet_plan_get.md
@@ -27,6 +27,7 @@ packet plan get [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_project.md
+++ b/docs/packet_project.md
@@ -19,6 +19,7 @@ Project operations: create, delete, update and get
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_project_create.md
+++ b/docs/packet_project_create.md
@@ -30,6 +30,7 @@ packet project create [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_project_delete.md
+++ b/docs/packet_project_delete.md
@@ -29,6 +29,7 @@ packet project delete [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_project_get.md
+++ b/docs/packet_project_get.md
@@ -35,6 +35,7 @@ packet project get [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_project_update.md
+++ b/docs/packet_project_update.md
@@ -30,6 +30,7 @@ packet project update [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_ssh-key.md
+++ b/docs/packet_ssh-key.md
@@ -19,6 +19,7 @@ SSH key operations: create, delete, update and get
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_ssh-key_create.md
+++ b/docs/packet_ssh-key_create.md
@@ -29,6 +29,7 @@ packet ssh-key create [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_ssh-key_delete.md
+++ b/docs/packet_ssh-key_delete.md
@@ -29,6 +29,7 @@ packet ssh-key delete [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_ssh-key_get.md
+++ b/docs/packet_ssh-key_get.md
@@ -32,6 +32,7 @@ packet ssh-key get [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_ssh-key_update.md
+++ b/docs/packet_ssh-key_update.md
@@ -30,6 +30,7 @@ packet ssh-key update [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_user.md
+++ b/docs/packet_user.md
@@ -19,6 +19,7 @@ User operations: get
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_user_get.md
+++ b/docs/packet_user_get.md
@@ -32,6 +32,7 @@ packet user get [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_virtual-network.md
+++ b/docs/packet_virtual-network.md
@@ -19,6 +19,7 @@ Virtual network operations: create, delete and get
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_virtual-network_create.md
+++ b/docs/packet_virtual-network_create.md
@@ -30,6 +30,7 @@ packet virtual-network create [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_virtual-network_delete.md
+++ b/docs/packet_virtual-network_delete.md
@@ -29,6 +29,7 @@ packet virtual-network delete [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_virtual-network_get.md
+++ b/docs/packet_virtual-network_get.md
@@ -28,6 +28,7 @@ packet virtual-network get [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_volume.md
+++ b/docs/packet_volume.md
@@ -19,6 +19,7 @@ Volume operations: create, delete, attach, detach and get
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_volume_attach.md
+++ b/docs/packet_volume_attach.md
@@ -29,6 +29,7 @@ packet volume attach [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_volume_create.md
+++ b/docs/packet_volume_create.md
@@ -34,6 +34,7 @@ packet volume create [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_volume_delete.md
+++ b/docs/packet_volume_delete.md
@@ -29,6 +29,7 @@ packet volume delete [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_volume_detach.md
+++ b/docs/packet_volume_detach.md
@@ -28,6 +28,7 @@ packet volume detach [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_volume_get.md
+++ b/docs/packet_volume_get.md
@@ -33,6 +33,7 @@ packet volume get [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_vpn.md
+++ b/docs/packet_vpn.md
@@ -19,6 +19,7 @@ VPN service operations: enable, disable, get
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_vpn_disable.md
+++ b/docs/packet_vpn_disable.md
@@ -27,6 +27,7 @@ packet vpn disable [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_vpn_enable.md
+++ b/docs/packet_vpn_enable.md
@@ -27,6 +27,7 @@ packet vpn enable [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/docs/packet_vpn_get.md
+++ b/docs/packet_vpn_get.md
@@ -28,6 +28,7 @@ packet vpn get [flags]
       --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
   -y, --yaml              YAML output
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/mattn/go-isatty v0.0.3 // indirect
 	github.com/mattn/go-runewidth v0.0.2 // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
-	github.com/packethost/packngo v0.4.1
+	github.com/packethost/packngo v0.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84 h1:fiKJgB4JDUd43CApkmCeTSQlWjtTtABrU2qsgbuP0BI=
 github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
-github.com/packethost/packngo v0.4.1 h1:HWeO3y3xvGIhdaW15VLz7uswKE27YRvXtONDjcMqvqk=
-github.com/packethost/packngo v0.4.1/go.mod h1:aRxUEV1TprXVcWr35v8tNYgZMjv7FHaInXx224vF2fc=
+github.com/packethost/packngo v0.5.0 h1:WGpfeRMstPqgyXGUXl6b9xFsbUudXU3p0+JlYri290U=
+github.com/packethost/packngo v0.5.0/go.mod h1:aRxUEV1TprXVcWr35v8tNYgZMjv7FHaInXx224vF2fc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=


### PR DESCRIPTION
For resources that support the `GET /resources?search=` parameter, this `--search` option will provide the presented keyword to the API.

The result of supplying a search parameter to any endpoint is currently undocumented.  In practice, if the keyword matches any one of the meaningful fields that are searched, that resource will be returned.  In some cases this may support partial values (description, hostname), in other cases, the match must be exact (IP Address).

When `?search=` is not supported by the resource, it will be silently ignored.  It will take some experimentation to discover which fields can be used for sorting, and on which resources. It will take additional experimentation to determine whether or not those fields are partial or precise.  Documentation is anticipated in support of these use cases.
