### PR TITLE
add capacity checking for metros

### DIFF
--- a/docs/packet_capacity.md
+++ b/docs/packet_capacity.md
@@ -27,5 +27,5 @@ Capacities operations: get, check
 
 * [packet](packet.md)	 - Command line interface for Equinix Metal
 * [packet capacity check](packet_capacity_check.md)	 - Validates if a deploy can be fulfilled.
-* [packet capacity get](packet_capacity_get.md)	 - Returns a list of facilities and plans with their current capacity.
+* [packet capacity get](packet_capacity_get.md)	 - Returns a list of facilities or metros and plans with their current capacity.
 

--- a/docs/packet_capacity_check.md
+++ b/docs/packet_capacity_check.md
@@ -6,7 +6,7 @@ Validates if a deploy can be fulfilled.
 
 Example:
 
-packet capacity check -f [facility] -p [plan] -q [quantity]
+packet capacity check {-m [metro] | -f [facility]} -p [plan] -q [quantity]
 
 	
 
@@ -19,6 +19,7 @@ packet capacity check [flags]
 ```
   -f, --facility string   Code of the facility
   -h, --help              help for check
+  -m, --metro string      Code of the metro
   -p, --plan string       Name of the plan
   -q, --quantity int      Number of devices wanted
 ```

--- a/docs/packet_capacity_get.md
+++ b/docs/packet_capacity_get.md
@@ -1,12 +1,12 @@
 ## packet capacity get
 
-Returns a list of facilities and plans with their current capacity.
+Returns a list of facilities or metros and plans with their current capacity.
 
 ### Synopsis
 
 Example:
 Retrieve capacities:
-packet capacity get
+packet capacity get { --metro | --facility }
 
 
 ```
@@ -16,7 +16,9 @@ packet capacity get [flags]
 ### Options
 
 ```
-  -h, --help   help for get
+  -f, --facility   Facility code (sv15) (default true)
+  -h, --help       help for get
+  -m, --metro      Metro code (sv)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Adds the ability to get capacity by metro:
```
packet capacity get -m
packet capacity check -m sv -p m2.medium.x86 -q 2
```