### PR TITLE
adds METAL_AUTH_TOKEN variable and env command

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -23,9 +23,10 @@ var (
 )
 
 const (
-	consumerToken  = "Equinix Metal CLI"
-	apiTokenEnvVar = "PACKET_TOKEN"
-	apiURL         = "https://api.equinix.com/metal/v1/"
+	consumerToken        = "Equinix Metal CLI"
+	apiTokenEnvVar       = "METAL_AUTH_TOKEN"
+	legacyApiTokenEnvVar = "PACKET_TOKEN"
+	apiURL               = "https://api.equinix.com/metal/v1/"
 )
 
 // NewCli struct

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -1,0 +1,61 @@
+/*
+Copyright © 2020 Equinix Metal Developers <support@equinixmetal.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// envCmd represents a command that, when run, generates a
+// set of environment variables, for use in shell environments
+var envCmd = &cobra.Command{
+	Use:   "env",
+	Short: "Generate environment variables",
+	Long: fmt.Sprintf(`Currently emitted variables:
+	- %s
+
+	To load environment variables:
+
+	Bash, Zsh:
+
+	$ source <(packet env)
+
+	Bash (3.2.x):
+
+	$ eval "$(packet env)"
+
+	Fish:
+
+	$ packet env | source
+	`, apiTokenEnvVar),
+	DisableFlagsInUseLine: true,
+	Hidden:                true,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("%s=%s\n", apiTokenEnvVar, packetToken)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(envCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,7 +55,7 @@ var rootCmd = &cobra.Command{
 
 func apiConnect(cmd *cobra.Command, args []string) error {
 	if packetToken == "" {
-		return fmt.Errorf("Equinix Metal authentication token not provided. Please either set the 'PACKET_TOKEN' environment variable or create a JSON or YAML configuration file.")
+		return fmt.Errorf("Equinix Metal authentication token not provided. Please set the 'METAL_AUTH_TOKEN' or 'PACKET_TOKEN' environment variable or create a JSON or YAML configuration file.")
 	}
 	client, err := packngo.NewClientWithBaseURL(consumerToken, packetToken, nil, apiURL)
 	if err != nil {
@@ -67,7 +67,11 @@ func apiConnect(cmd *cobra.Command, args []string) error {
 }
 
 func apiToken() string {
-	return os.Getenv(apiTokenEnvVar)
+	token := os.Getenv(apiTokenEnvVar)
+	if token != "" {
+		return token
+	}
+	return os.Getenv(legacyApiTokenEnvVar)
 }
 
 func init() {


### PR DESCRIPTION
Now checks for the `METAL_AUTH_TOKEN` environment variable, before checking `PACKET_TOKEN`. These variables are only checked if a config file is not found. While that order should be reversed, I am not introducing that change at this time.

Also adds `env` command works as follows:

```
$ eval $(packet env)
$ echo $METAL_AUTH_TOKEN
```

Fixes #107 
