### PR TITLE
dont hide docs,env,completion commands

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -64,7 +64,6 @@ var completionCmd = &cobra.Command{
 	$ packet completion fish > ~/.config/fish/completions/packet-cli.fish
 	`,
 	DisableFlagsInUseLine: true,
-	Hidden:                true,
 	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 	Args:                  cobra.ExactValidArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -32,7 +32,6 @@ var docsCmd = &cobra.Command{
 	Short:                 "Generate command documentation",
 	Long:                  "To generate documentation in the ./docs directory: docs ./docs",
 	DisableFlagsInUseLine: true,
-	Hidden:                true,
 	Args:                  cobra.ExactValidArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dest := args[0]

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -50,7 +50,6 @@ var envCmd = &cobra.Command{
 	$ packet env | source
 	`, apiTokenEnvVar),
 	DisableFlagsInUseLine: true,
-	Hidden:                true,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("%s=%s\n", apiTokenEnvVar, packetToken)
 	},

--- a/docs/packet.md
+++ b/docs/packet.md
@@ -22,7 +22,10 @@ Command line interface for Equinix Metal
 
 * [packet 2fa](packet_2fa.md)	 - Two Factor Authentication operations
 * [packet capacity](packet_capacity.md)	 - Capacities operations
+* [packet completion](packet_completion.md)	 - Generate completion script
 * [packet device](packet_device.md)	 - Device operations
+* [packet docs](packet_docs.md)	 - Generate command documentation
+* [packet env](packet_env.md)	 - Generate environment variables
 * [packet event](packet_event.md)	 - Events operations
 * [packet facilities](packet_facilities.md)	 - Facility operations
 * [packet hardware-reservation](packet_hardware-reservation.md)	 - Hardware reservation operations

--- a/docs/packet_completion.md
+++ b/docs/packet_completion.md
@@ -1,0 +1,62 @@
+## packet completion
+
+Generate completion script
+
+### Synopsis
+
+To load completions:
+
+	Bash:
+
+	$ source <(packet completion bash)
+
+	Bash (3.2.x):
+
+	$ eval "$(packet completion bash)"
+
+	# To load completions for each session, execute once:
+	Linux:
+	  $ packet completion bash > /etc/bash_completion.d/packet-cli
+	MacOS:
+	  $ packet completion bash > /usr/local/etc/bash_completion.d/packet-cli
+
+	Zsh:
+
+	$ source <(packet completion zsh)
+
+	# To load completions for each session, execute once:
+	$ packet completion zsh > "${fpath[1]}/_packet-cli"
+
+	Fish:
+
+	$ packet completion fish | source
+
+	# To load completions for each session, execute once:
+	$ packet completion fish > ~/.config/fish/completions/packet-cli.fish
+	
+
+```
+packet completion [bash|zsh|fish|powershell]
+```
+
+### Options
+
+```
+  -h, --help   help for completion
+```
+
+### Options inherited from parent commands
+
+```
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+  -y, --yaml              YAML output
+```
+
+### SEE ALSO
+
+* [packet](packet.md)	 - Command line interface for Equinix Metal
+

--- a/docs/packet_docs.md
+++ b/docs/packet_docs.md
@@ -1,0 +1,33 @@
+## packet docs
+
+Generate command documentation
+
+### Synopsis
+
+To generate documentation in the ./docs directory: docs ./docs
+
+```
+packet docs [DESTINATION]
+```
+
+### Options
+
+```
+  -h, --help   help for docs
+```
+
+### Options inherited from parent commands
+
+```
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+  -y, --yaml              YAML output
+```
+
+### SEE ALSO
+
+* [packet](packet.md)	 - Command line interface for Equinix Metal
+

--- a/docs/packet_env.md
+++ b/docs/packet_env.md
@@ -1,0 +1,49 @@
+## packet env
+
+Generate environment variables
+
+### Synopsis
+
+Currently emitted variables:
+	- METAL_AUTH_TOKEN
+
+	To load environment variables:
+
+	Bash, Zsh:
+
+	$ source <(packet env)
+
+	Bash (3.2.x):
+
+	$ eval "$(packet env)"
+
+	Fish:
+
+	$ packet env | source
+	
+
+```
+packet env
+```
+
+### Options
+
+```
+  -h, --help   help for env
+```
+
+### Options inherited from parent commands
+
+```
+      --config string     Path to JSON or YAML configuration file
+      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
+  -j, --json              JSON output
+      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+  -y, --yaml              YAML output
+```
+
+### SEE ALSO
+
+* [packet](packet.md)	 - Command line interface for Equinix Metal
+


### PR DESCRIPTION
* `packet help` should show all commands.
* `docs/` should have docs for all commands.

Revealing the hidden completion command resolves the last concern of https://github.com/packethost/packet-cli/issues/67#issuecomment-676813131

Fixes #67
