### PR TITLE
Change Config vs Env precedence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,6 @@ jobs:
     - name: Detect formatting and build errors
       run: make
       env:
-        PACKET_TOKEN: bogus
+        METAL_AUTH_TOKEN: bogus
     - name: Detect Uncommitted Docs
       run: git diff --exit-code docs

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -23,10 +23,9 @@ var (
 )
 
 const (
-	consumerToken        = "Equinix Metal CLI"
-	apiTokenEnvVar       = "METAL_AUTH_TOKEN"
-	legacyApiTokenEnvVar = "PACKET_TOKEN"
-	apiURL               = "https://api.equinix.com/metal/v1/"
+	consumerToken  = "Equinix Metal CLI"
+	apiTokenEnvVar = "METAL_AUTH_TOKEN"
+	apiURL         = "https://api.equinix.com/metal/v1/"
 )
 
 // NewCli struct

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -33,7 +33,7 @@ const (
 func NewCli() *Cli {
 	var err error
 	cli := &Cli{}
-	cli.Client, err = packngo.NewClientWithBaseURL(consumerToken, apiToken(), nil, apiURL)
+	cli.Client, err = packngo.NewClientWithBaseURL(consumerToken, metalToken, nil, apiURL)
 	if err != nil {
 		fmt.Println("Client error:", err)
 		return nil

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -33,6 +33,9 @@ var docsCmd = &cobra.Command{
 	Long:                  "To generate documentation in the ./docs directory: docs ./docs",
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.ExactValidArgs(1),
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dest := args[0]
 		return doc.GenMarkdownTree(cmd.Parent(), dest)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,7 @@ var (
 
 func apiConnect(cmd *cobra.Command, args []string) error {
 	if metalToken == "" {
-		return fmt.Errorf("Equinix Metal authentication token not provided. Please set the 'METAL_AUTH_TOKEN' or 'PACKET_TOKEN' environment variable or create a JSON or YAML configuration file.")
+		return fmt.Errorf("Equinix Metal authentication token not provided. Please set the 'METAL_AUTH_TOKEN' environment variable or create a JSON or YAML configuration file.")
 	}
 	client, err := packngo.NewClientWithBaseURL(consumerToken, metalToken, nil, apiURL)
 	if err != nil {
@@ -59,14 +59,6 @@ func apiConnect(cmd *cobra.Command, args []string) error {
 	client.UserAgent = fmt.Sprintf("metal-cli/%s %s", Version, client.UserAgent)
 	apiClient = *client
 	return nil
-}
-
-func apiToken() string {
-	token := os.Getenv(apiTokenEnvVar)
-	if token != "" {
-		return token
-	}
-	return os.Getenv(legacyApiTokenEnvVar)
 }
 
 func NewRootCommand() *cobra.Command {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,10 +124,11 @@ func initConfig() {
 		panic(fmt.Errorf("Could not read config: %s", err))
 	}
 
-	if viper.GetString("token") != "" {
-		metalToken = viper.GetString("token")
-	} else {
-		metalToken = apiToken()
+	metalToken = viper.GetString("token")
+
+	envToken := apiToken()
+	if envToken != "" {
+		metalToken = envToken
 	}
 }
 

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -17,7 +17,7 @@ const binaryName = "metal"
 
 const (
 	consumerToken  = "Equinix Metal CLI"
-	apiTokenEnvVar = "PACKET_TOKEN"
+	apiTokenEnvVar = "METAL_AUTH_TOKEN"
 	apiURL         = "https://api.equinix.com/metal/v1/"
 )
 


### PR DESCRIPTION
Fixes #126 

Base branch is `metal`, changes will be part of the _new_ metal-cli.

This PR gives `METAL_AUTH_TOKEN` precedence over `token` set in `~/.config/equinix/metal.yaml`. Previously, the environment variable was only used if no config value was set.

`PACKET_TOKEN` support is dropped.

Viper is used to fetch environment variables and config file variables.  These changes come from #90 and will allow for a cleaner PR to solve #54. 
