### PR TITLE
select default project id from config

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -49,7 +49,6 @@ func NewCli() *Cli {
 	}
 
 	rootClient := root.NewClient(consumerToken, apiURL, Version)
-	rootClient.Init()
 	rootCmd := rootClient.NewCommand()
 	rootCmd.DisableSuggestions = false
 	cli.MainCmd = rootCmd

--- a/docs/metal.md
+++ b/docs/metal.md
@@ -15,6 +15,7 @@ Command line interface for Equinix Metal
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_2fa.md
+++ b/docs/metal_2fa.md
@@ -20,6 +20,7 @@ Two Factor Authentication operations: enable, disable, receive
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_2fa_disable.md
+++ b/docs/metal_2fa_disable.md
@@ -7,10 +7,10 @@ Disables two factor authentication
 Example:
 
 Disable two factor authentication via SMS
-metal 2fa disable -s -t [token]
+metal 2fa disable -s -c [code]
 
 Disable two factor authentication via APP
-metal 2fa disable -a -t [token]
+metal 2fa disable -a -c [code]
 
 
 ```
@@ -20,10 +20,10 @@ metal 2fa disable [flags]
 ### Options
 
 ```
-  -a, --app            Issues otp uri for auth application
-  -h, --help           help for disable
-  -s, --sms            Issues SMS otp token to user's phone
-  -t, --token string   Two factor authentication token
+  -a, --app           Issues otp uri for auth application
+  -c, --code string   Two factor authentication code
+  -h, --help          help for disable
+  -s, --sms           Issues SMS otp token to user's phone
 ```
 
 ### Options inherited from parent commands
@@ -34,6 +34,7 @@ metal 2fa disable [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_2fa_enable.md
+++ b/docs/metal_2fa_enable.md
@@ -7,10 +7,10 @@ Enables two factor authentication
 Example:
 
 Enable two factor authentication via SMS
-metal 2fa enable -s -t [token]
+metal 2fa enable -s -c [code]
 
 Enable two factor authentication via APP
-metal 2fa enable -a -t [token]
+metal 2fa enable -a -c [code]
 
 
 ```
@@ -20,10 +20,10 @@ metal 2fa enable [flags]
 ### Options
 
 ```
-  -a, --app            Issues otp uri for auth application
-  -h, --help           help for enable
-  -s, --sms            Issues SMS otp token to user's phone
-  -t, --token string   Two factor authentication token
+  -a, --app           Issues otp uri for auth application
+  -c, --code string   Two factor authentication code
+  -h, --help          help for enable
+  -s, --sms           Issues SMS otp token to user's phone
 ```
 
 ### Options inherited from parent commands
@@ -34,6 +34,7 @@ metal 2fa enable [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_2fa_receive.md
+++ b/docs/metal_2fa_receive.md
@@ -33,6 +33,7 @@ metal 2fa receive [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_capacity.md
+++ b/docs/metal_capacity.md
@@ -20,6 +20,7 @@ Capacities operations: get, check
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_capacity_check.md
+++ b/docs/metal_capacity_check.md
@@ -32,6 +32,7 @@ metal capacity check [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_capacity_get.md
+++ b/docs/metal_capacity_get.md
@@ -29,6 +29,7 @@ metal capacity get [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_completion.md
+++ b/docs/metal_completion.md
@@ -53,6 +53,7 @@ metal completion [bash|zsh|fish|powershell]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_device.md
+++ b/docs/metal_device.md
@@ -20,6 +20,7 @@ Device operations: create, delete, update, start/stop, reboot and get.
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_device_create.md
+++ b/docs/metal_device_create.md
@@ -28,7 +28,7 @@ metal device create [flags]
   -m, --metro string                     Code of the metro where the device will be created
   -o, --operating-system string          Operating system name for the device
   -P, --plan string                      Name of the plan
-  -p, --project-id string                UUID of the project where the device will be created
+  -p, --project-id string                Project ID (METAL_PROJECT_ID) where the device will be created
   -v, --public-ipv4-subnet-size int      Size of the public IPv4 subnet
   -I, --spot-instance                    Set the device as a spot instance
       --spot-price-max float             --spot-price-max=1.2 or -m=1.2
@@ -46,6 +46,7 @@ metal device create [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_device_delete.md
+++ b/docs/metal_device_delete.md
@@ -30,6 +30,7 @@ metal device delete [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_device_get.md
+++ b/docs/metal_device_get.md
@@ -19,7 +19,7 @@ metal device get [flags]
 ```
   -h, --help                help for get
   -i, --id string           UUID of the device
-  -p, --project-id string   UUID of the project
+  -p, --project-id string   Project ID (METAL_PROJECT_ID)
 ```
 
 ### Options inherited from parent commands
@@ -30,6 +30,7 @@ metal device get [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_device_reboot.md
+++ b/docs/metal_device_reboot.md
@@ -29,6 +29,7 @@ metal device reboot [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_device_start.md
+++ b/docs/metal_device_start.md
@@ -29,6 +29,7 @@ metal device start [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_device_stop.md
+++ b/docs/metal_device_stop.md
@@ -29,6 +29,7 @@ metal device stop [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_device_update.md
+++ b/docs/metal_device_update.md
@@ -37,6 +37,7 @@ metal device update [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_docs.md
+++ b/docs/metal_docs.md
@@ -24,6 +24,7 @@ metal docs [DESTINATION]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_env.md
+++ b/docs/metal_env.md
@@ -6,6 +6,7 @@ Generate environment variables
 
 Currently emitted variables:
 	- METAL_AUTH_TOKEN
+	- METAL_PROJECT_ID
 
 	To load environment variables:
 
@@ -29,7 +30,8 @@ metal env
 ### Options
 
 ```
-  -h, --help   help for env
+  -h, --help                help for env
+  -p, --project-id string   Project ID (METAL_PROJECT_ID)
 ```
 
 ### Options inherited from parent commands
@@ -40,6 +42,7 @@ metal env
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_event.md
+++ b/docs/metal_event.md
@@ -20,6 +20,7 @@ Events operations: get
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_event_get.md
+++ b/docs/metal_event_get.md
@@ -37,7 +37,7 @@ metal event get [flags]
   -h, --help                     help for get
   -i, --id string                UUID of the event
   -o, --organization-id string   UUID of the organization
-  -p, --project-id string        UUID of the project
+  -p, --project-id string        Project ID (METAL_PROJECT_ID)
 ```
 
 ### Options inherited from parent commands
@@ -48,6 +48,7 @@ metal event get [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_facilities.md
+++ b/docs/metal_facilities.md
@@ -20,6 +20,7 @@ Facility operations: get
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_facilities_get.md
+++ b/docs/metal_facilities_get.md
@@ -28,6 +28,7 @@ metal facilities get [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_hardware-reservation.md
+++ b/docs/metal_hardware-reservation.md
@@ -20,6 +20,7 @@ Hardware reservation operations: get, move
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_hardware-reservation_get.md
+++ b/docs/metal_hardware-reservation_get.md
@@ -21,7 +21,7 @@ metal hardware-reservation get [flags]
 ```
   -h, --help                help for get
   -i, --id string           UUID of the hardware reservation
-  -p, --project-id string   UUID of the project
+  -p, --project-id string   Project ID (METAL_PROJECT_ID)
 ```
 
 ### Options inherited from parent commands
@@ -32,6 +32,7 @@ metal hardware-reservation get [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_hardware-reservation_move.md
+++ b/docs/metal_hardware-reservation_move.md
@@ -18,7 +18,7 @@ metal hardware-reservation move [flags]
 ```
   -h, --help                help for move
   -i, --id string           UUID of the hardware reservation
-  -p, --project-id string   UUID of the project
+  -p, --project-id string   Project ID (METAL_PROJECT_ID)
 ```
 
 ### Options inherited from parent commands
@@ -29,6 +29,7 @@ metal hardware-reservation move [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_ip.md
+++ b/docs/metal_ip.md
@@ -20,6 +20,7 @@ IP address, reservations and assignment operations: assign, unassign, remove, av
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_ip_assign.md
+++ b/docs/metal_ip_assign.md
@@ -30,6 +30,7 @@ metal ip assign [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_ip_available.md
+++ b/docs/metal_ip_available.md
@@ -30,6 +30,7 @@ metal ip available [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_ip_get.md
+++ b/docs/metal_ip_get.md
@@ -29,7 +29,7 @@ metal ip get [flags]
 ```
   -a, --assignment-id string    UUID of the assignment
   -h, --help                    help for get
-  -p, --project-id string       UUID of the project
+  -p, --project-id string       Project ID (METAL_PROJECT_ID)
   -r, --reservation-id string   UUID of the reservation
 ```
 
@@ -41,6 +41,7 @@ metal ip get [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_ip_remove.md
+++ b/docs/metal_ip_remove.md
@@ -29,6 +29,7 @@ metal ip remove [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_ip_request.md
+++ b/docs/metal_ip_request.md
@@ -20,7 +20,7 @@ metal ip request [flags]
   -c, --comments string     General comments
   -f, --facility string     Code of the facility
   -h, --help                help for request
-  -p, --project-id string   UUID of the project
+  -p, --project-id string   Project ID (METAL_PROJECT_ID)
   -q, --quantity int        Number of IP addresses to reserve
       --tags strings        Tags to add, comma-separated for multiple, or repeat multiple times
   -t, --type string         Address type public_ipv4 or global_ipv6
@@ -34,6 +34,7 @@ metal ip request [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_ip_unassign.md
+++ b/docs/metal_ip_unassign.md
@@ -29,6 +29,7 @@ metal ip unassign [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_metros.md
+++ b/docs/metal_metros.md
@@ -20,6 +20,7 @@ Metro operations: get
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_metros_get.md
+++ b/docs/metal_metros_get.md
@@ -28,6 +28,7 @@ metal metros get [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_operating-systems.md
+++ b/docs/metal_operating-systems.md
@@ -20,6 +20,7 @@ Operating system operations: get
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_operating-systems_get.md
+++ b/docs/metal_operating-systems_get.md
@@ -25,6 +25,7 @@ metal operating-systems get [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_organization.md
+++ b/docs/metal_organization.md
@@ -20,6 +20,7 @@ Organization operations: create, update, delete and get
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_organization_create.md
+++ b/docs/metal_organization_create.md
@@ -33,6 +33,7 @@ metal organization create [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_organization_delete.md
+++ b/docs/metal_organization_delete.md
@@ -30,6 +30,7 @@ metal organization delete [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_organization_get.md
+++ b/docs/metal_organization_get.md
@@ -33,6 +33,7 @@ metal organization get [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_organization_payment-methods.md
+++ b/docs/metal_organization_payment-methods.md
@@ -29,6 +29,7 @@ metal organization payment-methods [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_organization_update.md
+++ b/docs/metal_organization_update.md
@@ -34,6 +34,7 @@ metal organization update [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_plan.md
+++ b/docs/metal_plan.md
@@ -20,6 +20,7 @@ Plan operations: get
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_plan_get.md
+++ b/docs/metal_plan_get.md
@@ -28,6 +28,7 @@ metal plan get [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_project.md
+++ b/docs/metal_project.md
@@ -20,6 +20,7 @@ Project operations: create, delete, update and get
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_project_create.md
+++ b/docs/metal_project_create.md
@@ -31,6 +31,7 @@ metal project create [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_project_delete.md
+++ b/docs/metal_project_delete.md
@@ -19,7 +19,7 @@ metal project delete [flags]
 ```
   -f, --force       Force removal of the project
   -h, --help        help for delete
-  -i, --id string   UUID of the project
+  -i, --id string   Project ID (METAL_PROJECT_ID)
 ```
 
 ### Options inherited from parent commands
@@ -30,6 +30,7 @@ metal project delete [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_project_get.md
+++ b/docs/metal_project_get.md
@@ -23,9 +23,9 @@ metal project get [flags]
 ### Options
 
 ```
-  -h, --help                help for get
-  -n, --project string      Name of the project
-  -i, --project-id string   UUID of the project
+  -h, --help             help for get
+  -i, --id string        Project ID (METAL_PROJECT_ID)
+  -n, --project string   Name of the project
 ```
 
 ### Options inherited from parent commands
@@ -36,6 +36,7 @@ metal project get [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_project_update.md
+++ b/docs/metal_project_update.md
@@ -18,7 +18,7 @@ metal project update [flags]
 
 ```
   -h, --help                       help for update
-  -i, --id string                  UUID of the project
+  -i, --id string                  Project ID (METAL_PROJECT_ID)
   -n, --name string                Name for the project
   -m, --payment-method-id string   UUID of the payment method
 ```
@@ -31,6 +31,7 @@ metal project update [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_ssh-key.md
+++ b/docs/metal_ssh-key.md
@@ -20,6 +20,7 @@ SSH key operations: create, delete, update and get
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_ssh-key_create.md
+++ b/docs/metal_ssh-key_create.md
@@ -30,6 +30,7 @@ metal ssh-key create [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_ssh-key_delete.md
+++ b/docs/metal_ssh-key_delete.md
@@ -30,6 +30,7 @@ metal ssh-key delete [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_ssh-key_get.md
+++ b/docs/metal_ssh-key_get.md
@@ -33,6 +33,7 @@ metal ssh-key get [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_ssh-key_update.md
+++ b/docs/metal_ssh-key_update.md
@@ -31,6 +31,7 @@ metal ssh-key update [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_user.md
+++ b/docs/metal_user.md
@@ -20,6 +20,7 @@ User operations: get
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_user_get.md
+++ b/docs/metal_user_get.md
@@ -33,6 +33,7 @@ metal user get [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_virtual-network.md
+++ b/docs/metal_virtual-network.md
@@ -20,6 +20,7 @@ Virtual network operations: create, delete and get
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_virtual-network_create.md
+++ b/docs/metal_virtual-network_create.md
@@ -21,7 +21,7 @@ metal virtual-network create [flags]
   -f, --facility string      Code of the facility
   -h, --help                 help for create
   -m, --metro string         Code of the metro
-  -p, --project-id string    UUID of the project
+  -p, --project-id string    Project ID (METAL_PROJECT_ID)
       --vxlan int            VXLAN id to use (can only be used with --metro)
 ```
 
@@ -33,6 +33,7 @@ metal virtual-network create [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_virtual-network_delete.md
+++ b/docs/metal_virtual-network_delete.md
@@ -30,6 +30,7 @@ metal virtual-network delete [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/docs/metal_virtual-network_get.md
+++ b/docs/metal_virtual-network_get.md
@@ -18,7 +18,7 @@ metal virtual-network get [flags]
 
 ```
   -h, --help                help for get
-  -p, --project-id string   UUID of the project
+  -p, --project-id string   Project ID (METAL_PROJECT_ID)
 ```
 
 ### Options inherited from parent commands
@@ -29,6 +29,7 @@ metal virtual-network get [flags]
       --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
   -j, --json              JSON output
       --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --token string      Metal API Token (METAL_AUTH_TOKEN)
   -y, --yaml              YAML output
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/packethost/packngo v0.15.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/spf13/viper v1.7.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect

--- a/internal/capacity/capacity.go
+++ b/internal/capacity/capacity.go
@@ -39,7 +39,12 @@ func (c *Client) NewCommand() *cobra.Command {
 		Short: "Capacities operations",
 		Long:  `Capacities operations: get, check`,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			c.Service = c.Servicer.API().CapacityService
+			if root := cmd.Root(); root != nil {
+				if root.PersistentPreRun != nil {
+					root.PersistentPreRun(cmd, args)
+				}
+			}
+			c.Service = c.Servicer.API(cmd).CapacityService
 		},
 	}
 
@@ -51,7 +56,7 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API() *packngo.Client
+	API(*cobra.Command) *packngo.Client
 	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
 	Format() outputs.Format
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -26,14 +26,18 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"strings"
 
 	"github.com/packethost/packngo"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	outputPkg "github.com/equinix/metal-cli/internal/outputs"
 )
+
+const envPrefix = "METAL"
 
 type Client struct {
 	// apiClient client
@@ -50,6 +54,7 @@ type Client struct {
 	apiURL        string
 	Version       string
 	rootCmd       *cobra.Command
+	viper         *viper.Viper
 }
 
 func NewClient(consumerToken, apiURL, Version string) *Client {
@@ -61,9 +66,6 @@ func NewClient(consumerToken, apiURL, Version string) *Client {
 }
 
 func (c *Client) apiConnect() error {
-	if c.metalToken == "" {
-		return fmt.Errorf("Equinix Metal authentication token not provided. Please set the 'METAL_AUTH_TOKEN' environment variable or create a JSON or YAML configuration file.")
-	}
 	client, err := packngo.NewClientWithBaseURL(c.consumerToken, c.metalToken, nil, c.apiURL)
 	if err != nil {
 		return errors.Wrap(err, "Could not create Client")
@@ -73,7 +75,68 @@ func (c *Client) apiConnect() error {
 	return nil
 }
 
-func (c *Client) API() *packngo.Client {
+func (c *Client) Config(cmd *cobra.Command) *viper.Viper {
+	if c.viper == nil {
+		v := viper.New()
+		v.AutomaticEnv()
+
+		replacer := strings.NewReplacer("-", "_", ".", "_")
+		v.SetEnvKeyReplacer(replacer)
+		if c.cfgFile != "" {
+			// Use config file from the flag.
+			v.SetConfigFile(c.cfgFile)
+		} else {
+			configDir := path.Join(userHomeDir(), "/.config/equinix")
+			v.SetConfigName("metal")
+			v.AddConfigPath(configDir)
+		}
+
+		if err := v.ReadInConfig(); err != nil {
+			if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+				panic(fmt.Errorf("Could not read config: %s", err))
+			}
+		}
+
+		v.SetEnvPrefix(envPrefix)
+		c.viper = v
+		bindFlags(cmd, v)
+	}
+
+	flagToken := cmd.Flag("token").Value.String()
+	envToken := cmd.Flag("auth-token").Value.String()
+	// TODO: are we ok with this being configured by file too? yes?
+	// TODO: let cli arg take higher priority
+	c.metalToken = flagToken
+	if envToken != "" {
+		c.metalToken = envToken
+	}
+
+	return c.viper
+}
+
+// Credit to https://carolynvanslyck.com/blog/2020/08/sting-of-the-viper/
+func bindFlags(cmd *cobra.Command, v *viper.Viper) {
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		// Environment variables can't have dashes in them, so bind them to their equivalent
+		// keys with underscores, e.g. --favorite-color to STING_FAVORITE_COLOR
+		if strings.Contains(f.Name, "-") {
+			envVarSuffix := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
+			v.BindEnv(f.Name, fmt.Sprintf("%s_%s", envPrefix, envVarSuffix))
+		}
+
+		// Apply the viper config value to the flag when the flag is not set and viper has a value
+		if !f.Changed && v.IsSet(f.Name) {
+			val := v.Get(f.Name)
+			cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val))
+		}
+	})
+}
+
+func (c *Client) API(cmd *cobra.Command) *packngo.Client {
+	if c.metalToken == "" {
+		log.Fatal("Equinix Metal authentication token not provided. Please set the 'METAL_AUTH_TOKEN' environment variable or create a JSON or YAML configuration file.")
+	}
+
 	if c.apiClient == nil {
 		err := c.apiConnect()
 		if err != nil {
@@ -107,7 +170,14 @@ func (c *Client) NewCommand() *cobra.Command {
 		Short:             "Command line interface for Equinix Metal",
 		Long:              `Command line interface for Equinix Metal`,
 		DisableAutoGenTag: true,
+
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			c.Config(cmd)
+		},
 	}
+	rootCmd.PersistentFlags().String("token", "", "Metal API Token")
+	rootCmd.PersistentFlags().String("auth-token", "", "Metal API Token (Alias)")
+
 	rootCmd.PersistentFlags().StringVar(&c.cfgFile, "config", "", "Path to JSON or YAML configuration file")
 
 	rootCmd.PersistentFlags().BoolVarP(&c.isJSON, "json", "j", false, "JSON output")
@@ -143,31 +213,16 @@ func (c *Client) ListOptions(defaultIncludes, defaultExcludes []string) *packngo
 }
 
 // initConfig reads in config file and ENV variables if set.
-func (c *Client) Init() {
-	v := viper.New()
-	if c.cfgFile != "" {
-		// Use config file from the flag.
-		v.SetConfigFile(c.cfgFile)
-	} else {
-		configDir := path.Join(userHomeDir(), "/.config/equinix")
-		v.SetConfigName("metal")
-		v.AddConfigPath(configDir)
-	}
+func (c *Client) Init(cmd *cobra.Command) {
 
-	if err := v.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-			panic(fmt.Errorf("Could not read config: %s", err))
-		}
-	}
-
-	v.SetEnvPrefix("METAL")
-	v.AutomaticEnv()
-	c.metalToken = v.GetString("token")
-	envToken := v.GetString("auth_token")
+	//v := c.Config(cmd)
+	c.Config(cmd)
+	//c.metalToken = v.GetString("token")
+	//envToken := v.GetString("auth_token")
 	// TODO: are we ok with this being configured by file too? yes?
-	if envToken != "" {
-		c.metalToken = envToken
-	}
+	//if envToken != "" {
+	//		c.metalToken = envToken
+	//	}
 }
 
 func userHomeDir() string {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -175,9 +175,10 @@ func (c *Client) NewCommand() *cobra.Command {
 			c.Config(cmd)
 		},
 	}
-	rootCmd.PersistentFlags().String("token", "", "Metal API Token")
+	rootCmd.PersistentFlags().String("token", "", "Metal API Token (METAL_AUTH_TOKEN)")
 	rootCmd.PersistentFlags().String("auth-token", "", "Metal API Token (Alias)")
-
+	authtoken := rootCmd.PersistentFlags().Lookup("auth-token")
+	authtoken.Hidden = true
 	rootCmd.PersistentFlags().StringVar(&c.cfgFile, "config", "", "Path to JSON or YAML configuration file")
 
 	rootCmd.PersistentFlags().BoolVarP(&c.isJSON, "json", "j", false, "JSON output")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -121,13 +121,13 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) {
 		// keys with underscores, e.g. --favorite-color to STING_FAVORITE_COLOR
 		if strings.Contains(f.Name, "-") {
 			envVarSuffix := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
-			v.BindEnv(f.Name, fmt.Sprintf("%s_%s", envPrefix, envVarSuffix))
+			_ = v.BindEnv(f.Name, fmt.Sprintf("%s_%s", envPrefix, envVarSuffix))
 		}
 
 		// Apply the viper config value to the flag when the flag is not set and viper has a value
 		if !f.Changed && v.IsSet(f.Name) {
 			val := v.Get(f.Name)
-			cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val))
+			_ = cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val))
 		}
 	})
 }

--- a/internal/devices/create.go
+++ b/internal/devices/create.go
@@ -123,7 +123,7 @@ metal device create --hostname [hostname] --plan [plan] --metro [metro_code] --f
 			return c.Out.Output(device, header, &data)
 		},
 	}
-	createDeviceCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project where the device will be created")
+	createDeviceCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID (METAL_PROJECT_ID) where the device will be created")
 	viper.BindPFlag("project-id", createDeviceCmd.Flags().Lookup("project-id"))
 
 	createDeviceCmd.Flags().StringVarP(&facility, "facility", "f", "", "Code of the facility where the device will be created")

--- a/internal/devices/create.go
+++ b/internal/devices/create.go
@@ -124,7 +124,7 @@ metal device create --hostname [hostname] --plan [plan] --metro [metro_code] --f
 		},
 	}
 	createDeviceCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID (METAL_PROJECT_ID) where the device will be created")
-	viper.BindPFlag("project-id", createDeviceCmd.Flags().Lookup("project-id"))
+	_ = viper.BindPFlag("project-id", createDeviceCmd.Flags().Lookup("project-id"))
 
 	createDeviceCmd.Flags().StringVarP(&facility, "facility", "f", "", "Code of the facility where the device will be created")
 	createDeviceCmd.Flags().StringVarP(&metro, "metro", "m", "", "Code of the metro where the device will be created")

--- a/internal/devices/create.go
+++ b/internal/devices/create.go
@@ -28,6 +28,7 @@ import (
 	"github.com/packethost/packngo"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func (c *Client) Create() *cobra.Command {
@@ -123,6 +124,8 @@ metal device create --hostname [hostname] --plan [plan] --metro [metro_code] --f
 		},
 	}
 	createDeviceCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project where the device will be created")
+	viper.BindPFlag("project-id", createDeviceCmd.Flags().Lookup("project-id"))
+
 	createDeviceCmd.Flags().StringVarP(&facility, "facility", "f", "", "Code of the facility where the device will be created")
 	createDeviceCmd.Flags().StringVarP(&metro, "metro", "m", "", "Code of the metro where the device will be created")
 	createDeviceCmd.Flags().StringVarP(&plan, "plan", "P", "", "Name of the plan")

--- a/internal/devices/retrieve.go
+++ b/internal/devices/retrieve.go
@@ -75,7 +75,7 @@ metal device get --id [device_UUID]
 		},
 	}
 
-	retrieveDeviceCmd.Flags().StringP("project-id", "p", "", "UUID of the project")
+	retrieveDeviceCmd.Flags().StringP("project-id", "p", "", "Project ID (METAL_PROJECT_ID)")
 	retrieveDeviceCmd.Flags().StringP("id", "i", "", "UUID of the device")
 
 	return retrieveDeviceCmd

--- a/internal/devices/retrieve.go
+++ b/internal/devices/retrieve.go
@@ -28,21 +28,20 @@ import (
 )
 
 func (c *Client) Retrieve() *cobra.Command {
-	var (
-		projectID string
-		deviceID  string
-	)
-
 	var retrieveDeviceCmd = &cobra.Command{
 		Use:     "get",
 		Aliases: []string{"list"},
 		Short:   "Retrieves device list or device details",
+
 		Long: `Example:
 	
 metal device get --id [device_UUID]
 
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			deviceID, _ := cmd.Flags().GetString("id")
+			projectID, _ := cmd.Flags().GetString("project-id")
+
 			if deviceID != "" && projectID != "" {
 				return fmt.Errorf("Either id or project-id can be set.")
 			} else if deviceID == "" && projectID == "" {
@@ -75,8 +74,9 @@ metal device get --id [device_UUID]
 			return nil
 		},
 	}
-	retrieveDeviceCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project")
-	retrieveDeviceCmd.Flags().StringVarP(&deviceID, "id", "i", "", "UUID of the device")
+
+	retrieveDeviceCmd.Flags().StringP("project-id", "p", "", "UUID of the project")
+	retrieveDeviceCmd.Flags().StringP("id", "i", "", "UUID of the device")
 
 	return retrieveDeviceCmd
 }

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -78,8 +78,8 @@ func (c *Client) NewCommand() *cobra.Command {
 		},
 	}
 
-	// 	envCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project")
-	envCmd.Flags().StringP("project-id", "p", "", "UUID of the project")
+	// 	envCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID (METAL_PROJECT_ID)")
+	envCmd.Flags().StringP("project-id", "p", "", "Project ID (METAL_PROJECT_ID)")
 
 	return envCmd
 

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -46,11 +46,14 @@ func NewClient(t Tokener, apiTokenEnvVar string) *Client {
 func (c *Client) NewCommand() *cobra.Command {
 	// envCmd represents a command that, when run, generates a
 	// set of environment variables, for use in shell environments
-	return &cobra.Command{
+	//v := c.tokener.Config()
+	//projectId := v.GetString("project-id")
+	envCmd := &cobra.Command{
 		Use:   "env",
 		Short: "Generate environment variables",
 		Long: fmt.Sprintf(`Currently emitted variables:
 	- %s
+	- METAL_PROJECT_ID
 
 	To load environment variables:
 
@@ -68,7 +71,16 @@ func (c *Client) NewCommand() *cobra.Command {
 	`, c.apiTokenEnvVar),
 		DisableFlagsInUseLine: true,
 		Run: func(cmd *cobra.Command, args []string) {
+			projectID, _ := cmd.Flags().GetString("project-id")
+
 			fmt.Printf("%s=%s\n", c.apiTokenEnvVar, c.tokener.Token())
+			fmt.Printf("METAL_PROJECT_ID=%s\n", projectID)
 		},
 	}
+
+	// 	envCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project")
+	envCmd.Flags().StringP("project-id", "p", "", "UUID of the project")
+
+	return envCmd
+
 }

--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -43,10 +43,15 @@ func (c *Client) NewCommand() *cobra.Command {
 		Short:   "Events operations",
 		Long:    `Events operations: get`,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			c.EventService = c.Servicer.API().Events
-			c.DeviceService = c.Servicer.API().Devices
-			c.ProjectService = c.Servicer.API().Projects
-			c.OrganizationService = c.Servicer.API().Organizations
+			if root := cmd.Root(); root != nil {
+				if root.PersistentPreRun != nil {
+					root.PersistentPreRun(cmd, args)
+				}
+			}
+			c.EventService = c.Servicer.API(cmd).Events
+			c.DeviceService = c.Servicer.API(cmd).Devices
+			c.ProjectService = c.Servicer.API(cmd).Projects
+			c.OrganizationService = c.Servicer.API(cmd).Organizations
 		},
 	}
 
@@ -57,7 +62,7 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API() *packngo.Client
+	API(*cobra.Command) *packngo.Client
 	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
 	Format() outputs.Format
 }

--- a/internal/events/retrieve.go
+++ b/internal/events/retrieve.go
@@ -114,7 +114,7 @@ When using "--json" or "--yaml", "--include=relationships" is implied.
 		},
 	}
 	retrieveEventCmd.Flags().StringVarP(&eventID, "id", "i", "", "UUID of the event")
-	retrieveEventCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project")
+	retrieveEventCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID (METAL_PROJECT_ID)")
 	retrieveEventCmd.Flags().StringVarP(&deviceID, "device-id", "d", "", "UUID of the device")
 	retrieveEventCmd.Flags().StringVarP(&organizationID, "organization-id", "o", "", "UUID of the organization")
 	return retrieveEventCmd

--- a/internal/facilities/facility.go
+++ b/internal/facilities/facility.go
@@ -39,7 +39,12 @@ func (c *Client) NewCommand() *cobra.Command {
 		Short:   "Facility operations",
 		Long:    `Facility operations: get`,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			c.Service = c.Servicer.API().Facilities
+			if root := cmd.Root(); root != nil {
+				if root.PersistentPreRun != nil {
+					root.PersistentPreRun(cmd, args)
+				}
+			}
+			c.Service = c.Servicer.API(cmd).Facilities
 		},
 	}
 
@@ -50,7 +55,7 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API() *packngo.Client
+	API(*cobra.Command) *packngo.Client
 	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
 }
 

--- a/internal/hardware/hardware.go
+++ b/internal/hardware/hardware.go
@@ -38,9 +38,13 @@ func (c *Client) NewCommand() *cobra.Command {
 		Aliases: []string{"hardware-reservations", "hardware"},
 		Short:   "Hardware reservation operations",
 		Long:    `Hardware reservation operations: get, move`,
-
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			c.Service = c.Servicer.API().HardwareReservations
+			if root := cmd.Root(); root != nil {
+				if root.PersistentPreRun != nil {
+					root.PersistentPreRun(cmd, args)
+				}
+			}
+			c.Service = c.Servicer.API(cmd).HardwareReservations
 		},
 	}
 
@@ -52,7 +56,7 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API() *packngo.Client
+	API(*cobra.Command) *packngo.Client
 	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
 	Format() outputs.Format
 }

--- a/internal/hardware/move.go
+++ b/internal/hardware/move.go
@@ -51,7 +51,7 @@ metal hardware_reservation move -i [hardware_reservation_UUID] -p [project_UUID]
 	}
 
 	moveHardwareReservationCmd.Flags().StringVarP(&hardwareReservationID, "id", "i", "", "UUID of the hardware reservation")
-	moveHardwareReservationCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project")
+	moveHardwareReservationCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID (METAL_PROJECT_ID)")
 	_ = moveHardwareReservationCmd.MarkFlagRequired("project-id")
 	_ = moveHardwareReservationCmd.MarkFlagRequired("id")
 

--- a/internal/hardware/retrieve.go
+++ b/internal/hardware/retrieve.go
@@ -30,7 +30,6 @@ import (
 )
 
 func (c *Client) Retrieve() *cobra.Command {
-	var projectID, hardwareReservationID string
 	var retrieveHardwareReservationsCmd = &cobra.Command{
 		Use:     "get",
 		Aliases: []string{"list"},
@@ -42,7 +41,11 @@ metal hardware_reservations get -p [project_id]
 
 When using "--json" or "--yaml", "--include=project,facility,device" is implied.
 	`,
+
 		RunE: func(cmd *cobra.Command, args []string) error {
+			projectID, _ := cmd.Flags().GetString("project-id")
+			hardwareReservationID, _ := cmd.Flags().GetString("id")
+
 			header := []string{"ID", "Facility", "Plan", "Created"}
 
 			inc := []string{}
@@ -89,8 +92,8 @@ When using "--json" or "--yaml", "--include=project,facility,device" is implied.
 		},
 	}
 
-	retrieveHardwareReservationsCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project")
-	retrieveHardwareReservationsCmd.Flags().StringVarP(&hardwareReservationID, "id", "i", "", "UUID of the hardware reservation")
+	retrieveHardwareReservationsCmd.Flags().StringP("project-id", "p", "", "UUID of the project")
+	retrieveHardwareReservationsCmd.Flags().StringP("id", "i", "", "UUID of the hardware reservation")
 
 	return retrieveHardwareReservationsCmd
 }

--- a/internal/hardware/retrieve.go
+++ b/internal/hardware/retrieve.go
@@ -92,7 +92,7 @@ When using "--json" or "--yaml", "--include=project,facility,device" is implied.
 		},
 	}
 
-	retrieveHardwareReservationsCmd.Flags().StringP("project-id", "p", "", "UUID of the project")
+	retrieveHardwareReservationsCmd.Flags().StringP("project-id", "p", "", "Project ID (METAL_PROJECT_ID)")
 	retrieveHardwareReservationsCmd.Flags().StringP("id", "i", "", "UUID of the hardware reservation")
 
 	return retrieveHardwareReservationsCmd

--- a/internal/ips/ip.go
+++ b/internal/ips/ip.go
@@ -41,8 +41,13 @@ func (c *Client) NewCommand() *cobra.Command {
 		Long:    `IP address, reservations and assignment operations: assign, unassign, remove, available, request and get `,
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			c.ProjectService = c.Servicer.API().ProjectIPs
-			c.DeviceService = c.Servicer.API().DeviceIPs
+			if root := cmd.Root(); root != nil {
+				if root.PersistentPreRun != nil {
+					root.PersistentPreRun(cmd, args)
+				}
+			}
+			c.ProjectService = c.Servicer.API(cmd).ProjectIPs
+			c.DeviceService = c.Servicer.API(cmd).DeviceIPs
 		},
 	}
 
@@ -58,7 +63,7 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API() *packngo.Client
+	API(*cobra.Command) *packngo.Client
 	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
 }
 

--- a/internal/ips/request.go
+++ b/internal/ips/request.go
@@ -70,7 +70,7 @@ metal ip request --quantity [quantity] --facility [facility_code] --type [addres
 		},
 	}
 
-	requestIPCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project")
+	requestIPCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID (METAL_PROJECT_ID)")
 	requestIPCmd.Flags().StringVarP(&ttype, "type", "t", "", "Address type public_ipv4 or global_ipv6")
 	requestIPCmd.Flags().StringVarP(&facility, "facility", "f", "", "Code of the facility")
 	requestIPCmd.Flags().IntVarP(&quantity, "quantity", "q", 0, "Number of IP addresses to reserve")

--- a/internal/ips/retrieve.go
+++ b/internal/ips/retrieve.go
@@ -105,7 +105,7 @@ metal ip get --reservation-id [reservation_UUID]
 		},
 	}
 
-	retrieveIPCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project")
+	retrieveIPCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID (METAL_PROJECT_ID)")
 	retrieveIPCmd.Flags().StringVarP(&assignmentID, "assignment-id", "a", "", "UUID of the assignment")
 	retrieveIPCmd.Flags().StringVarP(&reservationID, "reservation-id", "r", "", "UUID of the reservation")
 	return retrieveIPCmd

--- a/internal/metros/metro.go
+++ b/internal/metros/metro.go
@@ -39,7 +39,12 @@ func (c *Client) NewCommand() *cobra.Command {
 		Short:   "Metro operations",
 		Long:    `Metro operations: get`,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			c.Service = c.Servicer.API().Metros
+			if root := cmd.Root(); root != nil {
+				if root.PersistentPreRun != nil {
+					root.PersistentPreRun(cmd, args)
+				}
+			}
+			c.Service = c.Servicer.API(cmd).Metros
 		},
 	}
 
@@ -50,7 +55,7 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API() *packngo.Client
+	API(*cobra.Command) *packngo.Client
 	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
 }
 

--- a/internal/organizations/organization.go
+++ b/internal/organizations/organization.go
@@ -40,7 +40,12 @@ func (c *Client) NewCommand() *cobra.Command {
 		Long:    `Organization operations: create, update, delete and get`,
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			c.Service = c.Servicer.API().Organizations
+			if root := cmd.Root(); root != nil {
+				if root.PersistentPreRun != nil {
+					root.PersistentPreRun(cmd, args)
+				}
+			}
+			c.Service = c.Servicer.API(cmd).Organizations
 		},
 	}
 
@@ -55,7 +60,7 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API() *packngo.Client
+	API(*cobra.Command) *packngo.Client
 	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
 	Format() outputs.Format
 }

--- a/internal/os/os.go
+++ b/internal/os/os.go
@@ -39,7 +39,12 @@ func (c *Client) NewCommand() *cobra.Command {
 		Short:   "Operating system operations",
 		Long:    `Operating system operations: get`,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			c.Service = c.Servicer.API().OperatingSystems
+			if root := cmd.Root(); root != nil {
+				if root.PersistentPreRun != nil {
+					root.PersistentPreRun(cmd, args)
+				}
+			}
+			c.Service = c.Servicer.API(cmd).OperatingSystems
 		},
 	}
 
@@ -50,7 +55,7 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API() *packngo.Client
+	API(*cobra.Command) *packngo.Client
 	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
 }
 

--- a/internal/plans/plan.go
+++ b/internal/plans/plan.go
@@ -39,7 +39,12 @@ func (c *Client) NewCommand() *cobra.Command {
 		Short:   "Plan operations",
 		Long:    `Plan operations: get`,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			c.Service = c.Servicer.API().Plans
+			if root := cmd.Root(); root != nil {
+				if root.PersistentPreRun != nil {
+					root.PersistentPreRun(cmd, args)
+				}
+			}
+			c.Service = c.Servicer.API(cmd).Plans
 		},
 	}
 
@@ -50,7 +55,7 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API() *packngo.Client
+	API(*cobra.Command) *packngo.Client
 	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
 }
 

--- a/internal/projects/delete.go
+++ b/internal/projects/delete.go
@@ -66,7 +66,7 @@ metal project delete --id [project_UUID]
 		},
 	}
 
-	deleteProjectCmd.Flags().StringVarP(&projectID, "id", "i", "", "UUID of the project")
+	deleteProjectCmd.Flags().StringVarP(&projectID, "id", "i", "", "Project ID (METAL_PROJECT_ID)")
 	_ = deleteProjectCmd.MarkFlagRequired("id")
 
 	deleteProjectCmd.Flags().BoolVarP(&force, "force", "f", false, "Force removal of the project")

--- a/internal/projects/project.go
+++ b/internal/projects/project.go
@@ -40,7 +40,12 @@ func (c *Client) NewCommand() *cobra.Command {
 		Long:    `Project operations: create, delete, update and get`,
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			c.Service = c.Servicer.API().Projects
+			if root := cmd.Root(); root != nil {
+				if root.PersistentPreRun != nil {
+					root.PersistentPreRun(cmd, args)
+				}
+			}
+			c.Service = c.Servicer.API(cmd).Projects
 		},
 	}
 
@@ -54,7 +59,7 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API() *packngo.Client
+	API(*cobra.Command) *packngo.Client
 	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
 	Format() outputs.Format
 }

--- a/internal/projects/retrieve.go
+++ b/internal/projects/retrieve.go
@@ -106,6 +106,6 @@ When using "--json" or "--yaml", "--include=members" is implied.
 	}
 
 	retrieveProjectCmd.Flags().StringVarP(&projectName, "project", "n", "", "Name of the project")
-	retrieveProjectCmd.Flags().StringVarP(&projectID, "project-id", "i", "", "UUID of the project")
+	retrieveProjectCmd.Flags().StringVarP(&projectID, "id", "i", "", "UUID of the project")
 	return retrieveProjectCmd
 }

--- a/internal/projects/retrieve.go
+++ b/internal/projects/retrieve.go
@@ -106,6 +106,6 @@ When using "--json" or "--yaml", "--include=members" is implied.
 	}
 
 	retrieveProjectCmd.Flags().StringVarP(&projectName, "project", "n", "", "Name of the project")
-	retrieveProjectCmd.Flags().StringVarP(&projectID, "id", "i", "", "UUID of the project")
+	retrieveProjectCmd.Flags().StringVarP(&projectID, "id", "i", "", "Project ID (METAL_PROJECT_ID)")
 	return retrieveProjectCmd
 }

--- a/internal/projects/update.go
+++ b/internal/projects/update.go
@@ -59,7 +59,7 @@ metal project update --id [project_UUID] --name [new_name]
 		},
 	}
 
-	updateProjectCmd.Flags().StringVarP(&projectID, "id", "i", "", "UUID of the project")
+	updateProjectCmd.Flags().StringVarP(&projectID, "id", "i", "", "Project ID (METAL_PROJECT_ID)")
 	updateProjectCmd.Flags().StringVarP(&name, "name", "n", "", "Name for the project")
 	updateProjectCmd.Flags().StringVarP(&paymentMethodID, "payment-method-id", "m", "", "UUID of the payment method")
 

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -39,7 +39,12 @@ func (c *Client) NewCommand() *cobra.Command {
 		Long:  `SSH key operations: create, delete, update and get`,
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			c.Service = c.Servicer.API().SSHKeys
+			if root := cmd.Root(); root != nil {
+				if root.PersistentPreRun != nil {
+					root.PersistentPreRun(cmd, args)
+				}
+			}
+			c.Service = c.Servicer.API(cmd).SSHKeys
 		},
 	}
 
@@ -53,7 +58,7 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API() *packngo.Client
+	API(*cobra.Command) *packngo.Client
 	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
 }
 

--- a/internal/twofa/disable2fa.go
+++ b/internal/twofa/disable2fa.go
@@ -39,10 +39,10 @@ func (c *Client) Disable() *cobra.Command {
 		Long: `Example:
 
 Disable two factor authentication via SMS
-metal 2fa disable -s -t [token]
+metal 2fa disable -s -c [code]
 
 Disable two factor authentication via APP
-metal 2fa disable -a -t [token]
+metal 2fa disable -a -c [code]
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if sms == app {
@@ -65,7 +65,7 @@ metal 2fa disable -a -t [token]
 
 	disable2faCmd.Flags().BoolVarP(&sms, "sms", "s", false, "Issues SMS otp token to user's phone")
 	disable2faCmd.Flags().BoolVarP(&app, "app", "a", false, "Issues otp uri for auth application")
-	disable2faCmd.Flags().StringVarP(&token, "token", "t", "", "Two factor authentication token")
-	_ = disable2faCmd.MarkFlagRequired("token")
+	disable2faCmd.Flags().StringVarP(&token, "code", "c", "", "Two factor authentication code")
+	_ = disable2faCmd.MarkFlagRequired("code")
 	return disable2faCmd
 }

--- a/internal/twofa/enable2fa.go
+++ b/internal/twofa/enable2fa.go
@@ -39,10 +39,10 @@ func (c *Client) Enable() *cobra.Command {
 		Long: `Example:
 
 Enable two factor authentication via SMS
-metal 2fa enable -s -t [token]
+metal 2fa enable -s -c [code]
 
 Enable two factor authentication via APP
-metal 2fa enable -a -t [token]
+metal 2fa enable -a -c [code]
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if sms == app {
@@ -65,7 +65,7 @@ metal 2fa enable -a -t [token]
 
 	enable2faCmd.Flags().BoolVarP(&sms, "sms", "s", false, "Issues SMS otp token to user's phone")
 	enable2faCmd.Flags().BoolVarP(&app, "app", "a", false, "Issues otp uri for auth application")
-	enable2faCmd.Flags().StringVarP(&token, "token", "t", "", "Two factor authentication token")
-	_ = enable2faCmd.MarkFlagRequired("token")
+	enable2faCmd.Flags().StringVarP(&token, "code", "c", "", "Two factor authentication code")
+	_ = enable2faCmd.MarkFlagRequired("code")
 	return enable2faCmd
 }

--- a/internal/twofa/twofa.go
+++ b/internal/twofa/twofa.go
@@ -40,7 +40,12 @@ func (c *Client) NewCommand() *cobra.Command {
 		Long:    `Two Factor Authentication operations: enable, disable, receive`,
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			c.Service = c.Servicer.API().TwoFactorAuth
+			if root := cmd.Root(); root != nil {
+				if root.PersistentPreRun != nil {
+					root.PersistentPreRun(cmd, args)
+				}
+			}
+			c.Service = c.Servicer.API(cmd).TwoFactorAuth
 		},
 	}
 
@@ -53,7 +58,7 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API() *packngo.Client
+	API(*cobra.Command) *packngo.Client
 	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
 }
 

--- a/internal/users/user.go
+++ b/internal/users/user.go
@@ -40,7 +40,12 @@ func (c *Client) NewCommand() *cobra.Command {
 		Long:    `User operations: get`,
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			c.Service = c.Servicer.API().Users
+			if root := cmd.Root(); root != nil {
+				if root.PersistentPreRun != nil {
+					root.PersistentPreRun(cmd, args)
+				}
+			}
+			c.Service = c.Servicer.API(cmd).Users
 		},
 	}
 
@@ -51,7 +56,7 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API() *packngo.Client
+	API(*cobra.Command) *packngo.Client
 	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
 }
 

--- a/internal/vlan/create.go
+++ b/internal/vlan/create.go
@@ -68,7 +68,7 @@ metal virtual-network create --project-id [project_UUID] { --metro [metro_code] 
 		},
 	}
 
-	createVirtualNetworkCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project")
+	createVirtualNetworkCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID (METAL_PROJECT_ID)")
 	createVirtualNetworkCmd.Flags().StringVarP(&facility, "facility", "f", "", "Code of the facility")
 	createVirtualNetworkCmd.Flags().StringVarP(&metro, "metro", "m", "", "Code of the metro")
 	createVirtualNetworkCmd.Flags().StringVarP(&description, "description", "d", "", "Description of the virtual network")

--- a/internal/vlan/delete.go
+++ b/internal/vlan/delete.go
@@ -55,7 +55,7 @@ metal virtual-network delete -i [virtual_network_UUID]
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !force {
 				prompt := promptui.Prompt{
-					Label:     fmt.Sprintf("Are you sure you want to delete virual network %s", vnetID),
+					Label:     fmt.Sprintf("Are you sure you want to delete virtual network %s", vnetID),
 					IsConfirm: true,
 				}
 

--- a/internal/vlan/retrieve.go
+++ b/internal/vlan/retrieve.go
@@ -56,7 +56,7 @@ metal virtual-network get -p [project_UUID]
 			return c.Out.Output(vnets, header, &data)
 		},
 	}
-	retrieveVirtualNetworksCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "UUID of the project")
+	retrieveVirtualNetworksCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID (METAL_PROJECT_ID)")
 	_ = retrieveVirtualNetworksCmd.MarkFlagRequired("project-id")
 
 	return retrieveVirtualNetworksCmd

--- a/internal/vlan/vlan.go
+++ b/internal/vlan/vlan.go
@@ -40,7 +40,12 @@ func (c *Client) NewCommand() *cobra.Command {
 		Long:    `Virtual network operations: create, delete and get`,
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			c.Service = c.Servicer.API().ProjectVirtualNetworks
+			if root := cmd.Root(); root != nil {
+				if root.PersistentPreRun != nil {
+					root.PersistentPreRun(cmd, args)
+				}
+			}
+			c.Service = c.Servicer.API(cmd).ProjectVirtualNetworks
 		},
 	}
 
@@ -53,7 +58,7 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API() *packngo.Client
+	API(*cobra.Command) *packngo.Client
 	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
 }
 


### PR DESCRIPTION
Replaces #90

> This experimental branch will introduce the ability to define a default organization id and project id from the Packet CLI config file.
>
>  Project IDs are not memorable. It would be convenient to be able to packet device create with the fewest arguments possible.  The default facility and plan could be stored in the Packet CLI config, for example.
>
> The interplay of default values required arguments, and impliable arguments has the potential to complicate and simplify the UX.
>
> This is similar behavior to what one can expect from the Packet Web portal.
> Each user account has a default project and organization defined, so the values in the config file could be derived from the Packet API, or could fall back to those values when not provided in other commands.

Fixes #54

