### PR TITLE
use runtime detected version for go install binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The [Equinix Metal CLI binaries](https://github.com/equinix/metal-cli/releases) 
 If you have `go` installed, you can build and install the latest version with:
 
 ```sh
-go get -u github.com/equinix/metal-cli/cmd/metal
+go install github.com/equinix/metal-cli/cmd/metal@latest
 ```
 
 You can find the installed executable/binary in either `$GOPATH/bin` or `$HOME/go/bin` folder.

--- a/cmd/metal/main.go
+++ b/cmd/metal/main.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"os"
+	"runtime/debug"
 
 	"github.com/equinix/metal-cli/cmd"
 )
@@ -31,4 +32,19 @@ func main() {
 	if err := cli.MainCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
+}
+
+func init() {
+	// look for the default version and replace it, if found, from runtime build info
+	if cmd.Version != "devel" {
+		return
+	}
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+
+	// Version is set in artifacts built with -X github.com/equinix/metal-cli/cmd.Version=1.2.3
+	// Ensure version is also set when installed via go install github.com/equinix/metal-cli/cmd/metal
+	cmd.Version = bi.Main.Version
 }


### PR DESCRIPTION
When installed via `go install`, the reported version is `devel`. This should report the version specified in the go install arguments.

_Originally https://github.com/equinix/metal-cli/pull/140#issuecomment-884948534_