### PR TITLE
prefer device id retrieve argument when project id is also available

### DIFF
--- a/internal/devices/retrieve.go
+++ b/internal/devices/retrieve.go
@@ -42,10 +42,19 @@ metal device get --id [device_UUID]
 			deviceID, _ := cmd.Flags().GetString("id")
 			projectID, _ := cmd.Flags().GetString("project-id")
 
-			if deviceID != "" && projectID != "" {
-				return fmt.Errorf("Either id or project-id can be set.")
-			} else if deviceID == "" && projectID == "" {
+			if deviceID == "" && projectID == "" {
 				return fmt.Errorf("Either id or project-id should be set.")
+			} else if deviceID != "" {
+				device, _, err := c.Service.Get(deviceID, nil)
+				if err != nil {
+					return errors.Wrap(err, "Could not get Devices")
+				}
+				header := []string{"ID", "Hostname", "OS", "State", "Created"}
+
+				data := make([][]string, 1)
+				data[0] = []string{device.ID, device.Hostname, device.OS.Name, device.State, device.Created}
+
+				return c.Out.Output(device, header, &data)
 			} else if projectID != "" {
 				devices, _, err := c.Service.List(projectID, c.Servicer.ListOptions(nil, nil))
 				if err != nil {
@@ -59,17 +68,6 @@ metal device get --id [device_UUID]
 				header := []string{"ID", "Hostname", "OS", "State", "Created"}
 
 				return c.Out.Output(devices, header, &data)
-			} else if deviceID != "" {
-				device, _, err := c.Service.Get(deviceID, nil)
-				if err != nil {
-					return errors.Wrap(err, "Could not get Devices")
-				}
-				header := []string{"ID", "Hostname", "OS", "State", "Created"}
-
-				data := make([][]string, 1)
-				data[0] = []string{device.ID, device.Hostname, device.OS.Name, device.State, device.Created}
-
-				return c.Out.Output(device, header, &data)
 			}
 			return nil
 		},

--- a/internal/hardware/retrieve.go
+++ b/internal/hardware/retrieve.go
@@ -60,8 +60,18 @@ When using "--json" or "--yaml", "--include=project,facility,device" is implied.
 
 			if hardwareReservationID == "" && projectID == "" {
 				return fmt.Errorf("Either id or project-id should be set.")
-			} else if hardwareReservationID != "" && projectID != "" {
-				return fmt.Errorf("Either id or project-id can be set.")
+			} else if hardwareReservationID != "" {
+				getOpts := &packngo.GetOptions{Includes: listOpt.Includes, Excludes: listOpt.Excludes}
+				r, _, err := c.Service.Get(hardwareReservationID, getOpts)
+				if err != nil {
+					return errors.Wrap(err, "Could not get Hardware Reservation")
+				}
+
+				data := make([][]string, 1)
+
+				data[0] = []string{r.ID, r.Facility.Code, r.Plan.Name, r.CreatedAt.String()}
+
+				return c.Out.Output(r, header, &data)
 			} else if projectID != "" {
 				reservations, _, err := c.Service.List(projectID, listOpt)
 				if err != nil {
@@ -75,18 +85,6 @@ When using "--json" or "--yaml", "--include=project,facility,device" is implied.
 				}
 
 				return c.Out.Output(reservations, header, &data)
-			} else if hardwareReservationID != "" {
-				getOpts := &packngo.GetOptions{Includes: listOpt.Includes, Excludes: listOpt.Excludes}
-				r, _, err := c.Service.Get(hardwareReservationID, getOpts)
-				if err != nil {
-					return errors.Wrap(err, "Could not get Hardware Reservation")
-				}
-
-				data := make([][]string, 1)
-
-				data[0] = []string{r.ID, r.Facility.Code, r.Plan.Name, r.CreatedAt.String()}
-
-				return c.Out.Output(r, header, &data)
 			}
 			return nil
 		},


### PR DESCRIPTION
Part of #145 

Each retrieve action that has project id and id as conflicting arguments will need to be addressed.