### PR TITLE
feat: Output terraform format

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -235,6 +235,7 @@ func (c *Client) Format() outputPkg.Format {
 		break
 	case outputPkg.FormatTable,
 		outputPkg.FormatTerraform,
+		outputPkg.FormatCrossplane,
 		outputPkg.FormatJSON,
 		outputPkg.FormatYAML:
 		format = f

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -234,6 +234,7 @@ func (c *Client) Format() outputPkg.Format {
 	case "":
 		break
 	case outputPkg.FormatTable,
+		outputPkg.FormatTerraform,
 		outputPkg.FormatJSON,
 		outputPkg.FormatYAML:
 		format = f

--- a/internal/outputs/crossplane/format.go
+++ b/internal/outputs/crossplane/format.go
@@ -1,0 +1,68 @@
+package crossplane
+
+import (
+	"bytes"
+	"html/template"
+
+	"github.com/packethost/packngo"
+)
+
+const (
+	deviceFormat = `
+---
+apiVersion: server.metal.equinix.com/v1alpha2
+kind: Device
+metadata:
+  name: {{.Hostname}}
+  annotations:
+    crossplane.io/external-name: {{.ID}}
+spec:
+  ## Late-Initialization will provide the current values
+  ## so we don't specify them here.
+
+  forProvider:
+    hostname: {{.Hostname}}
+    plan: {{.Plan.Slug}}
+    metro: {{.Metro.Code}}
+    operatingSystem: {{.OS.Slug}}
+    billingCycle: {{.BillingCycle}}
+    locked: {{.Locked}}
+    tags: {{.Tags}}
+
+  ## The "default" provider will be used unless named here.
+  # providerConfigRef:
+  #  name: equinix-metal-provider
+
+  ## EM devices do not persist passwords in the API long. This
+  ## optional secret will not get the root pass for devices > 24h
+  # writeConnectionSecretToRef:
+  #  name: crossplane-example
+  #  namespace: crossplane-system
+
+  ## Do not delete devices that have been imported.
+  # reclaimPolicy: Retain
+`
+)
+
+func many(s string) string {
+	return `{{range .}}` + s + `{{end}}`
+}
+func Marshal(i interface{}) ([]byte, error) {
+	var f = ""
+	switch i.(type) {
+	case *packngo.Device:
+		f = deviceFormat
+	case []packngo.Device:
+		f = many(deviceFormat)
+	}
+	tmpl, err := template.New("crossplane").Parse(f)
+	if err != nil {
+		return nil, err
+	}
+	buf := new(bytes.Buffer)
+	err = tmpl.Execute(buf, i)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/outputs/crossplane/format.go
+++ b/internal/outputs/crossplane/format.go
@@ -10,7 +10,7 @@ import (
 const (
 	deviceFormat = `
 ---
-apiVersion: server.metal.equinix.com/v1alpha2
+apiVersion: devices.metal.equinix.jet.crossplane.io/v1alpha1
 kind: Device
 metadata:
   name: {{.Hostname}}
@@ -47,8 +47,9 @@ spec:
 func many(s string) string {
 	return `{{range .}}` + s + `{{end}}`
 }
+
 func Marshal(i interface{}) ([]byte, error) {
-	var f = ""
+	f := ""
 	switch i.(type) {
 	case *packngo.Device:
 		f = deviceFormat

--- a/internal/outputs/crossplane/format.go
+++ b/internal/outputs/crossplane/format.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"html/template"
 
-	"github.com/packethost/packngo"
+	metal "github.com/equinix/equinix-sdk-go/services/metalv1"
 )
 
 const (
@@ -51,10 +51,11 @@ func many(s string) string {
 func Marshal(i interface{}) ([]byte, error) {
 	f := ""
 	switch i.(type) {
-	case *packngo.Device:
+	case metal.Device:
 		f = deviceFormat
-	case []packngo.Device:
+	case []metal.Device:
 		f = many(deviceFormat)
+
 	}
 	tmpl, err := template.New("crossplane").Parse(f)
 	if err != nil {

--- a/internal/outputs/outputs.go
+++ b/internal/outputs/outputs.go
@@ -7,14 +7,17 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"sigs.k8s.io/yaml"
+
+	"github.com/equinix/metal-cli/internal/outputs/terraform"
 )
 
 type Format string
 
 const (
-	FormatTable Format = "table"
-	FormatJSON  Format = "json"
-	FormatYAML  Format = "yaml"
+	FormatTable     Format = "table"
+	FormatJSON      Format = "json"
+	FormatYAML      Format = "yaml"
+	FormatTerraform Format = "tf"
 )
 
 type Outputer interface {
@@ -24,6 +27,15 @@ type Outputer interface {
 
 type Standard struct {
 	Format Format
+}
+
+func outputTerraform(in interface{}) error {
+	output, err := terraform.Marshal(in)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(output))
+	return nil
 }
 
 func outputJSON(in interface{}) error {
@@ -49,6 +61,8 @@ func (o *Standard) Output(in interface{}, header []string, data *[][]string) err
 		return outputJSON(in)
 	} else if o.Format == FormatYAML {
 		return outputYAML(in)
+	} else if o.Format == FormatTerraform {
+		return outputTerraform(in)
 	} else {
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetAutoWrapText(false)

--- a/internal/outputs/outputs.go
+++ b/internal/outputs/outputs.go
@@ -8,16 +8,18 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"sigs.k8s.io/yaml"
 
+	"github.com/equinix/metal-cli/internal/outputs/crossplane"
 	"github.com/equinix/metal-cli/internal/outputs/terraform"
 )
 
 type Format string
 
 const (
-	FormatTable     Format = "table"
-	FormatJSON      Format = "json"
-	FormatYAML      Format = "yaml"
-	FormatTerraform Format = "tf"
+	FormatTable      Format = "table"
+	FormatJSON       Format = "json"
+	FormatYAML       Format = "yaml"
+	FormatTerraform  Format = "tf"
+	FormatCrossplane Format = "crossplane"
 )
 
 type Outputer interface {
@@ -27,6 +29,15 @@ type Outputer interface {
 
 type Standard struct {
 	Format Format
+}
+
+func outputCrossplane(in interface{}) error {
+	output, err := crossplane.Marshal(in)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(output))
+	return nil
 }
 
 func outputTerraform(in interface{}) error {
@@ -63,6 +74,8 @@ func (o *Standard) Output(in interface{}, header []string, data *[][]string) err
 		return outputYAML(in)
 	} else if o.Format == FormatTerraform {
 		return outputTerraform(in)
+	} else if o.Format == FormatCrossplane {
+		return outputCrossplane(in)
 	} else {
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetAutoWrapText(false)

--- a/internal/outputs/terraform/device.tf.gotmpl
+++ b/internal/outputs/terraform/device.tf.gotmpl
@@ -1,11 +1,26 @@
-# terraform import equinix_metal_device.{{.Hostname}} {{.ID}}
-resource "equinix_metal_device" "{{.Hostname}}" {
-  plan = "{{.Plan.Slug}}"
-  hostname = "{{.Hostname}}"
-  billing_cycle = "{{.BillingCycle}}"
-  metro = "{{.Metro.Code}}"
-  operating_system = "{{.OS.Slug}}"
-  project_id = "{{.Project.ID}}"
-
-  tags = {{.Tags}}
+# terraform import equinix_metal_device.example {{.Id}}
+resource "equinix_metal_device" "example" {
+  always_pxe                       = {{.AlwaysPxe}}
+  billing_cycle                    = {{.BillingCycle}}
+  custom_data                      = {{.Customdata | nullIfNilOrEmpty}}
+  description                      = {{.Description | nullIfNilOrEmpty}}
+  force_detach_volumes             = false
+{{- if .HardwareReservation }}
+  hardware_reservation_id          = {{.HardwareReservation.Id }}
+{{ else }}
+  hardware_reservation_id          = null
+{{- end }}
+  hostname                         = {{.Hostname}}
+  ipxe_script_url                  = {{.IpxeScriptUrl}}
+  metro                            = {{.Metro.Code}}
+  operating_system                 = {{.OperatingSystem.Slug}}
+  plan                             = {{.Plan.Slug}}
+  project_id                       = {{ hrefToID .Project.Href}}
+  project_ssh_key_ids              = null
+  storage                          = {{.Storage | nullIfNilOrEmpty}}
+  tags                             = {{.Tags}}
+  termination_time                 = {{.TerminationTime | nullIfNilOrEmpty}}
+  user_data                        = {{.Userdata | nullIfNilOrEmpty}} # sensitive
+  user_ssh_key_ids                 = null
+  wait_for_reservation_deprovision = false
 }

--- a/internal/outputs/terraform/device.tf.gotmpl
+++ b/internal/outputs/terraform/device.tf.gotmpl
@@ -1,0 +1,11 @@
+# terraform import equinix_metal_device.{{.Hostname}} {{.ID}}
+resource "equinix_metal_device" "{{.Hostname}}" {
+  plan = "{{.Plan.Slug}}"
+  hostname = "{{.Hostname}}"
+  billing_cycle = "{{.BillingCycle}}"
+  metro = "{{.Metro.Code}}"
+  operating_system = "{{.OS.Slug}}"
+  project_id = "{{.Project.ID}}"
+
+  tags = {{.Tags}}
+}

--- a/internal/outputs/terraform/format.go
+++ b/internal/outputs/terraform/format.go
@@ -1,0 +1,45 @@
+package terraform
+
+import (
+	"bytes"
+	"html/template"
+
+	"github.com/packethost/packngo"
+)
+
+const deviceFormat = `
+# terraform import metal_device.{{.Hostname}} {{.ID}}
+resource "metal_device" "{{.Hostname}}" {
+  plan = "{{.Plan.Slug}}"
+  hostname = "{{.Hostname}}"
+  billing_cycle = "{{.BillingCycle}}"
+  metro = "{{.Metro.Code}}"
+  operating_system = "{{.OS.Slug}}"
+  project_id = "{{.Project.ID}}"
+
+  tags = {{.Tags}}
+}
+`
+
+func many(s string) string {
+	return `{{range .}}` + s + `{{end}}`
+}
+func Marshal(i interface{}) ([]byte, error) {
+	var f = ""
+	switch i.(type) {
+	case *packngo.Device:
+		f = deviceFormat
+	case []packngo.Device:
+		f = many(deviceFormat)
+	}
+	tmpl, err := template.New("terraform").Parse(f)
+	if err != nil {
+		return nil, err
+	}
+	buf := new(bytes.Buffer)
+	err = tmpl.Execute(buf, i)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/outputs/terraform/format.go
+++ b/internal/outputs/terraform/format.go
@@ -7,7 +7,8 @@ import (
 	"html"
 	"html/template"
 	"path"
-	metal "github.com/equinix-labs/metal-go/metal/v1"
+
+	metal "github.com/equinix/equinix-sdk-go/services/metalv1"
 )
 
 var (

--- a/internal/outputs/terraform/project.tf.gotmpl
+++ b/internal/outputs/terraform/project.tf.gotmpl
@@ -1,0 +1,7 @@
+# terraform import equinix_metal_project.{{.Name}} {{.ID}}
+resource "equinix_metal_project" "{{.Name}}" {
+    name = "{{.Name}}"
+    organization_id = "{{.Organization.URL | hrefToID}}"
+    # TODO: bgp_config
+}
+

--- a/internal/outputs/terraform/utils.go
+++ b/internal/outputs/terraform/utils.go
@@ -1,0 +1,151 @@
+package terraform
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+)
+
+func addQuotesToString(v interface{}) {
+	val := reflect.ValueOf(v)
+
+	switch val.Kind() {
+	case reflect.Ptr:
+		val = val.Elem()
+		if val.Kind() != reflect.Struct {
+			return
+		}
+
+		if val.Type() == reflect.TypeOf(new(string)) {
+			oldValue := val.Elem().String()
+			newValue := fmt.Sprintf(`"%s"`, oldValue)
+			val.Elem().SetString(newValue)
+			return
+		}
+	case reflect.String:
+		oldValue := val.String()
+		newValue := fmt.Sprintf(`"%s"`, oldValue)
+		val.SetString(newValue)
+		return
+	case reflect.Slice:
+		for i := 0; i < val.Len(); i++ {
+			elem := val.Index(i)
+			if elem.Kind() == reflect.Struct || (elem.Kind() == reflect.Ptr && elem.Elem().Kind() == reflect.Struct) {
+				addQuotesToString(elem.Interface())
+			}
+		}
+		return
+	case reflect.Map:
+		for _, key := range val.MapKeys() {
+			elem := val.MapIndex(key)
+			if elem.Kind() == reflect.Struct || (elem.Kind() == reflect.Ptr && elem.Elem().Kind() == reflect.Struct) {
+				addQuotesToString(elem.Interface())
+			}
+		}
+		return
+	default:
+		return
+	}
+
+	for i := 0; i < val.NumField(); i++ {
+		field := val.Field(i)
+
+		switch field.Kind() {
+		case reflect.String:
+			oldValue := field.String()
+			newValue := fmt.Sprintf(`"%s"`, oldValue)
+			field.SetString(newValue)
+		case reflect.Ptr:
+			if field.IsNil() {
+				continue
+			}
+			// Check if the pointer is to a string
+			if field.Type().Elem() == reflect.TypeOf("") {
+				oldValue := field.Elem().String()
+				newValue := fmt.Sprintf(`"%s"`, oldValue)
+				field.Elem().SetString(newValue)
+			} else {
+				// Exclude *time.Time from recursion
+				if field.Type() != reflect.TypeOf(&time.Time{}) {
+					addQuotesToString(field.Interface())
+				}
+			}
+		case reflect.Struct:
+			// Exclude time.Time from recursion
+			if field.Type() != reflect.TypeOf(time.Time{}) {
+				addQuotesToString(field.Interface())
+			}
+		}
+	}
+}
+
+func nullIfNilOrEmpty(v interface{}) interface{} {
+    if v == nil {
+        return "null"
+    }
+
+    // Use reflection to check if the value is an empty value (e.g., empty string, empty slice, or empty map)
+    val := reflect.ValueOf(v)
+    switch val.Kind() {
+    case reflect.String:
+        if val.String() == "\"\"" {
+            return "null"
+        }
+    case reflect.Array, reflect.Slice, reflect.Map:
+        if val.Len() == 0 {
+            return "null"
+        }
+    case reflect.Ptr:
+        if val.IsNil() || val.IsZero() {
+            return "null"
+        }
+
+        elem := val.Elem()
+
+        // Check if it's a pointer to a string
+        if elem.Kind() == reflect.String && elem.String() == "\"\"" {
+            return "null"
+        }
+
+        switch elem.Kind() {
+        case reflect.Struct:
+			if isPointerStructEmpty(elem) {
+                return "null"
+            }
+        case reflect.Array, reflect.Slice:
+            if elem.Len() == 0 {
+                return "null"
+            }
+        case reflect.Map:
+            if elem.Len() == 0 {
+                return "null"
+            }
+        }
+    }
+
+    return v
+}
+
+func isPointerStructEmpty(structVal reflect.Value) bool {
+    // Iterate through the struct fields
+    for i := 0; i < structVal.NumField(); i++ {
+        field := structVal.Field(i)
+
+        // You can define custom logic to determine if a field is empty
+        // For example, check if a string field is empty, or if a slice/map field is empty
+        switch field.Kind() {
+        case reflect.String:
+            if field.String() != "" {
+                return false
+            }
+        case reflect.Slice, reflect.Map:
+            if field.Len() > 0 {
+                return false
+            }
+        // Add more cases for other field types as needed
+        }
+    }
+
+    // All fields are empty
+    return true
+}


### PR DESCRIPTION
This is a demonstration of how the Metal CLI can offer a Terraform output format for each supported resource type.
In this PR, since devices and device lists are translated into the most primitive Terraform HCL snippet, accompanied by the `terraform import` command needed to fetch the state of the configured resource.

The same pattern could be used to offer Crossplane and Ansible resources, among others. 

An elaborate use-case to consider is fetching a project, but rather than getting the single project resource, getting all objects contained within that project as HCL. The `--output` argument in that case may need sub-options (`--output=tf,deep`)

The hinted argument, `deep`, would walk all descendent resources. `metal project get -i $PROJECT_ID -o tf,deep`, for example, would generate TF config for the project, devices, IPs, VLANs, etc.

---
## All devices in the project

```sh
$ metal devices get -o tf
```
```hcl
# terraform import metal_device.ch-x1-small-x86-01 8cda1f07-378a-43f7-9c94-3ab2373a9660
resource "metal_device" "ch-x1-small-x86-01" {
  plan = "baremetal_1e"
  hostname = "ch-x1-small-x86-01"
  billing_cycle = "hourly"
  metro = "ch"
  operating_system = "ubuntu_20_10"
  project_id = ""

  tags = []
}

# terraform import metal_device.mj-test b925f22f-edc9-4d58-8f8b-55d99c5b7cae
resource "metal_device" "mj-test" {
  plan = "t1.small.x86"
  hostname = "mj-test"
  billing_cycle = "hourly"
  metro = "sv"
  operating_system = "ubuntu_21_04"
  project_id = ""

  tags = []
}
```

---
## A single devices in the project

```sh
$ metal devices get --id b925f22f-edc9-4d58-8f8b-55d99c5b7cae -o tf
```
```hcl
# terraform import metal_device.mj-test b925f22f-edc9-4d58-8f8b-55d99c5b7cae
resource "metal_device" "mj-test" {
  plan = "t1.small.x86"
  hostname = "mj-test"
  billing_cycle = "hourly"
  metro = "sv"
  operating_system = "ubuntu_21_04"
  project_id = ""

  tags = []
}
```

---

## Crossplane Format

The same single and multiple listing support can be used to emit Crossplane configuration.  With Crossplane, the controller will synchronize the EM API settings, so only the UUID (as external-name) must be set in the resource. 

See https://github.com/crossplane-contrib/provider-equinix-metal#install-the-equinix-metal-provider for more details about the EM Crossplane provider and https://crossplane.io/docs/v1.3/concepts/managed-resources.html for details on using Managed resources in Crossplane.

The utility this support would bring to the `metal-cli` has similar gains to the proposal for a `crossplane import` tool: https://github.com/crossplane/crossplane-cli/issues/66.


```sh
$ metal devices get  -o crossplane
```
```yaml
---
apiVersion: server.metal.equinix.com/v1alpha2
kind: Device
metadata:
  name: ch-x1-small-x86-01
  annotations:
    crossplane.io/external-name: 8cda1f07-378a-43f7-9c94-3ab2373a9660
spec:
  ## Late-Initialization will provide the current values
  ## so we don't specify them here.
  forProvider:
    hostname: ch-x1-small-x86-01
    plan: baremetal_1e
    metro: ch
    operatingSystem: ubuntu_20_10
    billingCycle: hourly
    locked: false
    tags: []

  ## The "default" provider will be used unless named here.
  # providerConfigRef:
  #  name: equinix-metal-provider

  ## EM devices do not persist passwords in the API long. This
  ## optional secret will not get the root pass for devices > 24h
  # writeConnectionSecretToRef:
  #  name: crossplane-example
  #  namespace: crossplane-system

  ## Do not delete devices that have been imported.
  # reclaimPolicy: Retain

---
apiVersion: server.metal.equinix.com/v1alpha2
kind: Device
metadata:
  name: mj-test
  annotations:
    crossplane.io/external-name: b925f22f-edc9-4d58-8f8b-55d99c5b7cae
spec:
  ## Late-Initialization will provide the current values
  ## so we don't specify them here.
  forProvider:
    hostname: mj-test
    plan: t1.small.x86
    metro: sv
    operatingSystem: ubuntu_21_04
    billingCycle: hourly
    locked: false
    tags: []

  ## The "default" provider will be used unless named here.
  # providerConfigRef:
  #  name: equinix-metal-provider

  ## EM devices do not persist passwords in the API long. This
  ## optional secret will not get the root pass for devices > 24h
  # writeConnectionSecretToRef:
  #  name: crossplane-example
  #  namespace: crossplane-system

  ## Do not delete devices that have been imported.
  # reclaimPolicy: Retain
```