### PR TITLE
docs: add support page that was referenced but missing

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,3 @@
+If you require support, please email support@equinixmetal.com, subscribe to the [Equinix Metal Community Slack](https://slack.equinixmetal.com/) channel or post an issue within this repository.
+
+[Contributions](CONTRIBUTING.md) are welcome to help extend this work!


### PR DESCRIPTION
support.md was referenced but missing in the repo, adding following similar that was made in this PR  https://github.com/equinix/docker-machine-driver-metal/pull/51