### PR TITLE
Add support for filtering results (via arbitrary query parameters)

### DIFF
--- a/docs/metal.md
+++ b/docs/metal.md
@@ -9,15 +9,16 @@ Command line interface for Equinix Metal
 ### Options
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-  -h, --help              help for metal
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+  -h, --help                 help for metal
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_2fa.md
+++ b/docs/metal_2fa.md
@@ -15,14 +15,15 @@ Two Factor Authentication operations: enable, disable, receive
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_2fa_disable.md
+++ b/docs/metal_2fa_disable.md
@@ -29,14 +29,15 @@ metal 2fa disable [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_2fa_enable.md
+++ b/docs/metal_2fa_enable.md
@@ -29,14 +29,15 @@ metal 2fa enable [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_2fa_receive.md
+++ b/docs/metal_2fa_receive.md
@@ -28,14 +28,15 @@ metal 2fa receive [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_capacity.md
+++ b/docs/metal_capacity.md
@@ -15,14 +15,15 @@ Capacities operations: get, check
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_capacity_check.md
+++ b/docs/metal_capacity_check.md
@@ -27,14 +27,15 @@ metal capacity check [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_capacity_get.md
+++ b/docs/metal_capacity_get.md
@@ -24,14 +24,15 @@ metal capacity get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_completion.md
+++ b/docs/metal_completion.md
@@ -48,14 +48,15 @@ metal completion [bash|zsh|fish|powershell]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_device.md
+++ b/docs/metal_device.md
@@ -15,14 +15,15 @@ Device operations: create, delete, update, start/stop, reboot and get.
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_device_create.md
+++ b/docs/metal_device_create.md
@@ -41,14 +41,15 @@ metal device create [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_device_delete.md
+++ b/docs/metal_device_delete.md
@@ -25,14 +25,15 @@ metal device delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_device_get.md
+++ b/docs/metal_device_get.md
@@ -25,14 +25,15 @@ metal device get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_device_reboot.md
+++ b/docs/metal_device_reboot.md
@@ -24,14 +24,15 @@ metal device reboot [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_device_start.md
+++ b/docs/metal_device_start.md
@@ -24,14 +24,15 @@ metal device start [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_device_stop.md
+++ b/docs/metal_device_stop.md
@@ -24,14 +24,15 @@ metal device stop [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_device_update.md
+++ b/docs/metal_device_update.md
@@ -32,14 +32,15 @@ metal device update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_docs.md
+++ b/docs/metal_docs.md
@@ -19,14 +19,15 @@ metal docs [DESTINATION]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_env.md
+++ b/docs/metal_env.md
@@ -37,14 +37,15 @@ metal env
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_event.md
+++ b/docs/metal_event.md
@@ -15,14 +15,15 @@ Events operations: get
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_event_get.md
+++ b/docs/metal_event_get.md
@@ -43,14 +43,15 @@ metal event get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_facilities.md
+++ b/docs/metal_facilities.md
@@ -15,14 +15,15 @@ Facility operations: get
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_facilities_get.md
+++ b/docs/metal_facilities_get.md
@@ -23,14 +23,15 @@ metal facilities get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_hardware-reservation.md
+++ b/docs/metal_hardware-reservation.md
@@ -15,14 +15,15 @@ Hardware reservation operations: get, move
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_hardware-reservation_get.md
+++ b/docs/metal_hardware-reservation_get.md
@@ -27,14 +27,15 @@ metal hardware-reservation get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_hardware-reservation_move.md
+++ b/docs/metal_hardware-reservation_move.md
@@ -24,14 +24,15 @@ metal hardware-reservation move [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_init.md
+++ b/docs/metal_init.md
@@ -33,14 +33,15 @@ metal init
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_ip.md
+++ b/docs/metal_ip.md
@@ -15,14 +15,15 @@ IP address, reservations and assignment operations: assign, unassign, remove, av
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_ip_assign.md
+++ b/docs/metal_ip_assign.md
@@ -25,14 +25,15 @@ metal ip assign [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_ip_available.md
+++ b/docs/metal_ip_available.md
@@ -25,14 +25,15 @@ metal ip available [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_ip_get.md
+++ b/docs/metal_ip_get.md
@@ -36,14 +36,15 @@ metal ip get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_ip_remove.md
+++ b/docs/metal_ip_remove.md
@@ -24,14 +24,15 @@ metal ip remove [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_ip_request.md
+++ b/docs/metal_ip_request.md
@@ -29,14 +29,15 @@ metal ip request [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_ip_unassign.md
+++ b/docs/metal_ip_unassign.md
@@ -24,14 +24,15 @@ metal ip unassign [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_metros.md
+++ b/docs/metal_metros.md
@@ -15,14 +15,15 @@ Metro operations: get
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_metros_get.md
+++ b/docs/metal_metros_get.md
@@ -23,14 +23,15 @@ metal metros get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_operating-systems.md
+++ b/docs/metal_operating-systems.md
@@ -15,14 +15,15 @@ Operating system operations: get
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_operating-systems_get.md
+++ b/docs/metal_operating-systems_get.md
@@ -20,14 +20,15 @@ metal operating-systems get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_organization.md
+++ b/docs/metal_organization.md
@@ -15,14 +15,15 @@ Organization operations: create, update, delete and get
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_organization_create.md
+++ b/docs/metal_organization_create.md
@@ -28,14 +28,15 @@ metal organization create [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_organization_delete.md
+++ b/docs/metal_organization_delete.md
@@ -25,14 +25,15 @@ metal organization delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_organization_get.md
+++ b/docs/metal_organization_get.md
@@ -28,14 +28,15 @@ metal organization get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_organization_payment-methods.md
+++ b/docs/metal_organization_payment-methods.md
@@ -24,14 +24,15 @@ metal organization payment-methods [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_organization_update.md
+++ b/docs/metal_organization_update.md
@@ -29,14 +29,15 @@ metal organization update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_plan.md
+++ b/docs/metal_plan.md
@@ -15,14 +15,15 @@ Plan operations: get
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_plan_get.md
+++ b/docs/metal_plan_get.md
@@ -23,14 +23,15 @@ metal plan get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_project.md
+++ b/docs/metal_project.md
@@ -15,14 +15,15 @@ Project operations: create, delete, update and get
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_project_create.md
+++ b/docs/metal_project_create.md
@@ -26,14 +26,15 @@ metal project create [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_project_delete.md
+++ b/docs/metal_project_delete.md
@@ -25,14 +25,15 @@ metal project delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_project_get.md
+++ b/docs/metal_project_get.md
@@ -31,14 +31,15 @@ metal project get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_project_update.md
+++ b/docs/metal_project_update.md
@@ -26,14 +26,15 @@ metal project update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_ssh-key.md
+++ b/docs/metal_ssh-key.md
@@ -15,14 +15,15 @@ SSH key operations: create, delete, update and get
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_ssh-key_create.md
+++ b/docs/metal_ssh-key_create.md
@@ -25,14 +25,15 @@ metal ssh-key create [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_ssh-key_delete.md
+++ b/docs/metal_ssh-key_delete.md
@@ -25,14 +25,15 @@ metal ssh-key delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_ssh-key_get.md
+++ b/docs/metal_ssh-key_get.md
@@ -28,14 +28,15 @@ metal ssh-key get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_ssh-key_update.md
+++ b/docs/metal_ssh-key_update.md
@@ -26,14 +26,15 @@ metal ssh-key update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_user.md
+++ b/docs/metal_user.md
@@ -15,14 +15,15 @@ User operations: get
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_user_get.md
+++ b/docs/metal_user_get.md
@@ -28,14 +28,15 @@ metal user get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_virtual-network.md
+++ b/docs/metal_virtual-network.md
@@ -15,14 +15,15 @@ Virtual network operations: create, delete and get
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_virtual-network_create.md
+++ b/docs/metal_virtual-network_create.md
@@ -28,14 +28,15 @@ metal virtual-network create [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_virtual-network_delete.md
+++ b/docs/metal_virtual-network_delete.md
@@ -25,14 +25,15 @@ metal virtual-network delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/metal_virtual-network_get.md
+++ b/docs/metal_virtual-network_get.md
@@ -24,14 +24,15 @@ metal virtual-network get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Path to JSON or YAML configuration file
-      --exclude strings   Comma seperated Href references to collapse in results, may be dotted three levels deep
-      --include strings   Comma seperated Href references to expand in results, may be dotted three levels deep
-  -o, --output string     Output format (*table, json, yaml)
-      --search string     Search keyword for use in 'get' actions. Search is not supported by all resources.
-      --sort-by string    Sort fields for use in 'get' actions. Sort is not supported by all resources.
-      --sort-dir string   Sort field direction for use in 'get' actions. Sort is not supported by all resources.
-      --token string      Metal API Token (METAL_AUTH_TOKEN)
+      --config string        Path to JSON or YAML configuration file
+      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
+      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+  -o, --output string        Output format (*table, json, yaml)
+      --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
+      --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
+      --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.
+      --token string         Metal API Token (METAL_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/lunixbochs/vtclean v0.0.0-20170504063817-d14193dfc626 // indirect
 	github.com/manifoldco/promptui v0.3.0
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/packethost/packngo v0.17.0
+	github.com/packethost/packngo v0.20.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -150,8 +152,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/packethost/packngo v0.17.0 h1:fGPlj9NDt6ejOrAMfUgx955oCaR1QBKA9pec14m0L38=
-github.com/packethost/packngo v0.17.0/go.mod h1:YrtUNN9IRjjqN6zK+cy2IYoi3EjHfoWTWxJkI1I1Vk0=
+github.com/packethost/packngo v0.20.0 h1:vUU1z2q+x6/pfNCwHbmdoMrXl/lin8LBk24yqtp4ZjQ=
+github.com/packethost/packngo v0.20.0/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -307,6 +309,7 @@ golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -48,6 +48,7 @@ type Client struct {
 
 	includes      *[]string // nolint:unused
 	excludes      *[]string // nolint:unused
+	filters       *[]string
 	search        string
 	sortBy        string
 	sortDir       string
@@ -195,6 +196,7 @@ func (c *Client) NewCommand() *cobra.Command {
 	rootCmd.PersistentFlags().StringVarP(&c.outputFormat, "output", "o", "", "Output format (*table, json, yaml)")
 	c.includes = rootCmd.PersistentFlags().StringSlice("include", nil, "Comma seperated Href references to expand in results, may be dotted three levels deep")
 	c.excludes = rootCmd.PersistentFlags().StringSlice("exclude", nil, "Comma seperated Href references to collapse in results, may be dotted three levels deep")
+	c.filters = rootCmd.PersistentFlags().StringSlice("filter", nil, "Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.")
 	rootCmd.PersistentFlags().StringVar(&c.search, "search", "", "Search keyword for use in 'get' actions. Search is not supported by all resources.")
 	rootCmd.PersistentFlags().StringVar(&c.sortBy, "sort-by", "", "Sort fields for use in 'get' actions. Sort is not supported by all resources.")
 	rootCmd.PersistentFlags().StringVar(&c.sortDir, "sort-dir", "", "Sort field direction for use in 'get' actions. Sort is not supported by all resources.")
@@ -216,6 +218,14 @@ func (c *Client) ListOptions(defaultIncludes, defaultExcludes []string) *packngo
 	}
 	if c.rootCmd.Flags().Changed("exclude") {
 		listOptions.Excludes = *c.excludes
+	}
+	if c.rootCmd.Flags().Changed("filter") {
+		for _, kv := range *c.filters {
+			tokens := strings.SplitN(kv, "=", 2)
+			k := strings.TrimSpace(tokens[0])
+			v := strings.TrimSpace(tokens[1])
+			listOptions = listOptions.Filter(k, v)
+		}
 	}
 	if c.rootCmd.Flags().Changed("search") {
 		listOptions.Search = c.search

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -196,7 +196,7 @@ func (c *Client) NewCommand() *cobra.Command {
 	rootCmd.PersistentFlags().StringVarP(&c.outputFormat, "output", "o", "", "Output format (*table, json, yaml)")
 	c.includes = rootCmd.PersistentFlags().StringSlice("include", nil, "Comma seperated Href references to expand in results, may be dotted three levels deep")
 	c.excludes = rootCmd.PersistentFlags().StringSlice("exclude", nil, "Comma seperated Href references to collapse in results, may be dotted three levels deep")
-	c.filters = rootCmd.PersistentFlags().StringSlice("filter", nil, "Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.")
+	c.filters = rootCmd.PersistentFlags().StringArray("filter", nil, "Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.")
 	rootCmd.PersistentFlags().StringVar(&c.search, "search", "", "Search keyword for use in 'get' actions. Search is not supported by all resources.")
 	rootCmd.PersistentFlags().StringVar(&c.sortBy, "sort-by", "", "Sort fields for use in 'get' actions. Sort is not supported by all resources.")
 	rootCmd.PersistentFlags().StringVar(&c.sortDir, "sort-dir", "", "Sort field direction for use in 'get' actions. Sort is not supported by all resources.")
@@ -221,9 +221,12 @@ func (c *Client) ListOptions(defaultIncludes, defaultExcludes []string) *packngo
 	}
 	if c.rootCmd.Flags().Changed("filter") {
 		for _, kv := range *c.filters {
+			var k, v string
 			tokens := strings.SplitN(kv, "=", 2)
-			k := strings.TrimSpace(tokens[0])
-			v := strings.TrimSpace(tokens[1])
+			k = strings.TrimSpace(tokens[0])
+			if len(tokens) != 1 {
+				v = strings.TrimSpace(tokens[1])
+			}
 			listOptions = listOptions.Filter(k, v)
 		}
 	}


### PR DESCRIPTION
Fixes #157 

Enables filtering via query parameters:

```
metal devices list --filter type=spot
```