### PR TITLE
Check capacity against multiple metros, facilities, and plans at once

### DIFF
--- a/docs/metal_capacity.md
+++ b/docs/metal_capacity.md
@@ -29,6 +29,6 @@ Capacities operations: get, check
 ### SEE ALSO
 
 * [metal](metal.md)	 - Command line interface for Equinix Metal
-* [metal capacity check](metal_capacity_check.md)	 - Validates if a deploy can be fulfilled.
+* [metal capacity check](metal_capacity_check.md)	 - Validates if a deploy can be fulfilled with the given quantity in any of the given locations and plans
 * [metal capacity get](metal_capacity_get.md)	 - Returns a list of facilities or metros and plans with their current capacity.
 

--- a/docs/metal_capacity_check.md
+++ b/docs/metal_capacity_check.md
@@ -1,27 +1,25 @@
 ## metal capacity check
 
-Validates if a deploy can be fulfilled.
-
-### Synopsis
-
-Example:
-
-metal capacity check {-m [metro] | -f [facility]} -p [plan] -q [quantity]
-
-	
+Validates if a deploy can be fulfilled with the given quantity in any of the given locations and plans
 
 ```
-metal capacity check [flags]
+metal capacity check {-m [metros,...] | -f [facilities,...]} -P [plans,...] -q [quantity] [flags]
+```
+
+### Examples
+
+```
+metal capacity check -m sv,ny,da -P c3.large.arm,c3.medium.x86 -q 10
 ```
 
 ### Options
 
 ```
-  -f, --facility string   Code of the facility
-  -h, --help              help for check
-  -m, --metro string      Code of the metro
-  -P, --plan string       Name of the plan
-  -q, --quantity int      Number of devices wanted
+  -f, --facilities strings   Codes of the facilities
+  -h, --help                 help for check
+  -m, --metros strings       Codes of the metros
+  -P, --plans strings        Names of the plans
+  -q, --quantity int         Number of devices wanted
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
fixes #158

Deprecations:
* `--plan` becomes `--plans` (`-P` is backwards compatible, `--plan` adds to `--plans` args)
* `--metro` becomes `--metros` (`-m` is backwards compatible, `--metro` adds to `--metros` args)
* `--facility` becomes `--facilities` (`-f` is backwards compatible, `--facility` adds to `--facilities` args)

```
$ go run ./cmd/metal/main.go  capacity check -m sv,ny -P c3.small,c3.medium -q 10 
+-------+-----------+----------+--------------+
| METRO |   PLAN    | QUANTITY | AVAILABILITY |
+-------+-----------+----------+--------------+
| sv    | c3.small  | 10       | true         |
| sv    | c3.medium | 10       | true         |
| ny    | c3.small  | 10       | false        |
| ny    | c3.medium | 10       | true         |
+-------+-----------+----------+--------------+
```