### PR TITLE
silence usage messages when usage was valid and API errors are returned

### DIFF
--- a/internal/capacity/check.go
+++ b/internal/capacity/check.go
@@ -53,6 +53,12 @@ func (c *Client) Check() *cobra.Command {
 			if facility != "" {
 				facilities = append(facilities, facility)
 			}
+
+			if (len(facilities) > 0) == (len(metros) > 0) {
+				return errors.New("Either facilities or metros should be set")
+			}
+			cmd.SilenceUsage = true
+
 			if plan != "" {
 				plans = append(plans, plan)
 			}
@@ -87,8 +93,6 @@ func (c *Client) Check() *cobra.Command {
 						)
 					}
 				}
-			} else {
-				return errors.New("Either facility or metro should be set")
 			}
 
 			availability, _, err := checker(req)

--- a/internal/capacity/retrieve.go
+++ b/internal/capacity/retrieve.go
@@ -40,6 +40,7 @@ Retrieve capacities:
 metal capacity get { --metro | --facility }
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			var err error
 			lister := c.Service.List
 			fieldName := "Facility"

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -68,6 +68,7 @@ func NewCommand() *cobra.Command {
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 		Args:                  cobra.ExactValidArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			switch args[0] {
 			case "bash":
 				return cmd.Root().GenBashCompletion(os.Stdout)
@@ -82,6 +83,7 @@ func NewCommand() *cobra.Command {
 			return fmt.Errorf("unknown shell: %q", args[0])
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			return nil
 		},
 	}

--- a/internal/devices/create.go
+++ b/internal/devices/create.go
@@ -69,6 +69,7 @@ metal device create --hostname [hostname] --plan [plan] --metro [metro_code] --f
 			if userdata != "" && userdataFile != "" {
 				return fmt.Errorf("Either userdata or userdata-file should be set")
 			}
+			cmd.SilenceUsage = true
 
 			if userdataFile != "" {
 				userdataRaw, readErr := ioutil.ReadFile(userdataFile)

--- a/internal/devices/delete.go
+++ b/internal/devices/delete.go
@@ -48,6 +48,7 @@ func (c *Client) Delete() *cobra.Command {
   
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			if !force {
 				prompt := promptui.Prompt{
 					Label:     fmt.Sprintf("Are you sure you want to delete device %s: ", deviceID),

--- a/internal/devices/reboot.go
+++ b/internal/devices/reboot.go
@@ -39,6 +39,7 @@ metal device reboot --id [device_UUID]
 
 	  `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			_, err := c.Service.Reboot(deviceID)
 			if err != nil {
 				return errors.Wrap(err, "Could not reboot Device")

--- a/internal/devices/retrieve.go
+++ b/internal/devices/retrieve.go
@@ -44,7 +44,10 @@ metal device get --id [device_UUID]
 
 			if deviceID == "" && projectID == "" {
 				return fmt.Errorf("Either id or project-id should be set.")
-			} else if deviceID != "" {
+			}
+			cmd.SilenceUsage = true
+
+			if deviceID != "" {
 				device, _, err := c.Service.Get(deviceID, nil)
 				if err != nil {
 					return errors.Wrap(err, "Could not get Devices")
@@ -55,21 +58,20 @@ metal device get --id [device_UUID]
 				data[0] = []string{device.ID, device.Hostname, device.OS.Name, device.State, device.Created}
 
 				return c.Out.Output(device, header, &data)
-			} else if projectID != "" {
-				devices, _, err := c.Service.List(projectID, c.Servicer.ListOptions(nil, nil))
-				if err != nil {
-					return errors.Wrap(err, "Could not list Devices")
-				}
-				data := make([][]string, len(devices))
-
-				for i, dc := range devices {
-					data[i] = []string{dc.ID, dc.Hostname, dc.OS.Name, dc.State, dc.Created}
-				}
-				header := []string{"ID", "Hostname", "OS", "State", "Created"}
-
-				return c.Out.Output(devices, header, &data)
 			}
-			return nil
+
+			devices, _, err := c.Service.List(projectID, c.Servicer.ListOptions(nil, nil))
+			if err != nil {
+				return errors.Wrap(err, "Could not list Devices")
+			}
+			data := make([][]string, len(devices))
+
+			for i, dc := range devices {
+				data[i] = []string{dc.ID, dc.Hostname, dc.OS.Name, dc.State, dc.Created}
+			}
+			header := []string{"ID", "Hostname", "OS", "State", "Created"}
+
+			return c.Out.Output(devices, header, &data)
 		},
 	}
 

--- a/internal/devices/start.go
+++ b/internal/devices/start.go
@@ -39,6 +39,7 @@ metal device start --id [device_UUID]
 
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			_, err := c.Service.PowerOn(deviceID)
 
 			if err != nil {

--- a/internal/devices/stop.go
+++ b/internal/devices/stop.go
@@ -38,6 +38,7 @@ func (c *Client) Stop() *cobra.Command {
   
   `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			_, err := c.Service.PowerOff(deviceID)
 
 			if err != nil {

--- a/internal/devices/update.go
+++ b/internal/devices/update.go
@@ -51,6 +51,7 @@ metal device update --id [device_UUID] --hostname [new_hostname]
 
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			req := &packngo.DeviceUpdateRequest{}
 
 			if hostname != "" {

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -34,9 +34,11 @@ func NewCommand() *cobra.Command {
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactValidArgs(1),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			dest := args[0]
 			return doc.GenMarkdownTree(cmd.Parent(), dest)
 		},

--- a/internal/events/retrieve.go
+++ b/internal/events/retrieve.go
@@ -58,6 +58,7 @@ metal event get
 When using "--json" or "--yaml", "--include=relationships" is implied.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			var events []packngo.Event
 			var err error
 			header := []string{"ID", "Body", "Type", "Created"}

--- a/internal/facilities/retrieve.go
+++ b/internal/facilities/retrieve.go
@@ -38,6 +38,7 @@ metal facilities get
 	
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			facilities, _, err := c.Service.List(c.Servicer.ListOptions(nil, nil))
 			if err != nil {
 				return errors.Wrap(err, "Could not list Facilities")

--- a/internal/hardware/move.go
+++ b/internal/hardware/move.go
@@ -36,6 +36,7 @@ func (c *Client) Move() *cobra.Command {
 metal hardware_reservation move -i [hardware_reservation_UUID] -p [project_UUID]
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			header := []string{"ID", "Facility", "Plan", "Created"}
 			r, _, err := c.Service.Move(hardwareReservationID, projectID)
 			if err != nil {

--- a/internal/hardware/retrieve.go
+++ b/internal/hardware/retrieve.go
@@ -60,7 +60,10 @@ When using "--json" or "--yaml", "--include=project,facility,device" is implied.
 
 			if hardwareReservationID == "" && projectID == "" {
 				return fmt.Errorf("Either id or project-id should be set.")
-			} else if hardwareReservationID != "" {
+			}
+
+			cmd.SilenceUsage = true
+			if hardwareReservationID != "" {
 				getOpts := &packngo.GetOptions{Includes: listOpt.Includes, Excludes: listOpt.Excludes}
 				r, _, err := c.Service.Get(hardwareReservationID, getOpts)
 				if err != nil {
@@ -72,21 +75,20 @@ When using "--json" or "--yaml", "--include=project,facility,device" is implied.
 				data[0] = []string{r.ID, r.Facility.Code, r.Plan.Name, r.CreatedAt.String()}
 
 				return c.Out.Output(r, header, &data)
-			} else if projectID != "" {
-				reservations, _, err := c.Service.List(projectID, listOpt)
-				if err != nil {
-					return errors.Wrap(err, "Could not list Hardware Reservations")
-				}
-
-				data := make([][]string, len(reservations))
-
-				for i, r := range reservations {
-					data[i] = []string{r.ID, r.Facility.Code, r.Plan.Name, r.CreatedAt.String()}
-				}
-
-				return c.Out.Output(reservations, header, &data)
 			}
-			return nil
+
+			reservations, _, err := c.Service.List(projectID, listOpt)
+			if err != nil {
+				return errors.Wrap(err, "Could not list Hardware Reservations")
+			}
+
+			data := make([][]string, len(reservations))
+
+			for i, r := range reservations {
+				data[i] = []string{r.ID, r.Facility.Code, r.Plan.Name, r.CreatedAt.String()}
+			}
+
+			return c.Out.Output(reservations, header, &data)
 		},
 	}
 

--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -78,6 +78,7 @@ func (c *Client) NewCommand() *cobra.Command {
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			cmd.SilenceUsage = true
 			config, _ := cmd.Flags().GetString("config")
 			if config == "" {
 				config = c.Servicer.DefaultConfig(true)

--- a/internal/ips/assign.go
+++ b/internal/ips/assign.go
@@ -44,6 +44,7 @@ metal ip assign -d [device-id] -a [ip-address]
 
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			assignment, _, err := c.DeviceService.Assign(deviceID, &packngo.AddressStruct{Address: address})
 			if err != nil {
 				return errors.Wrap(err, "Could not assign Device IP address")

--- a/internal/ips/available.go
+++ b/internal/ips/available.go
@@ -42,6 +42,7 @@ metal ip available --reservation-id [reservation_id] --cidr [size_of_subnet]
 
   `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			result, _, err := c.ProjectService.AvailableAddresses(reservationID, &packngo.AvailableRequest{CIDR: cidr})
 
 			if err != nil {

--- a/internal/ips/remove.go
+++ b/internal/ips/remove.go
@@ -39,6 +39,7 @@ metal ip remove --id [reservation-UUID]
 
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			_, err := c.ProjectService.Remove(reservationID)
 			if err != nil {
 				return errors.Wrap(err, "Could not remove IP address Reservation")

--- a/internal/ips/request.go
+++ b/internal/ips/request.go
@@ -49,6 +49,7 @@ metal ip request --quantity [quantity] --facility [facility_code] --type [addres
 
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			req := &packngo.IPReservationRequest{
 				Type:     ttype,
 				Quantity: quantity,

--- a/internal/ips/retrieve.go
+++ b/internal/ips/retrieve.go
@@ -58,7 +58,14 @@ metal ip get --reservation-id [reservation_UUID]
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if assignmentID != "" && reservationID != "" {
 				return fmt.Errorf("Either assignment-id or reservation-id can be set.")
-			} else if assignmentID != "" {
+			}
+
+			if assignmentID == "" && reservationID == "" && projectID == "" {
+				return fmt.Errorf("Either project-id or assignment-id or reservation-id must be set.")
+			}
+
+			cmd.SilenceUsage = true
+			if assignmentID != "" {
 				ip, _, err := c.ProjectService.Get(assignmentID, nil)
 				if err != nil {
 					return errors.Wrap(err, "Could not get Device IP address")
@@ -82,27 +89,25 @@ metal ip get --reservation-id [reservation_UUID]
 				header := []string{"ID", "Address", "Facility", "Public", "Created"}
 
 				return c.Out.Output(ip, header, &data)
-			} else if projectID != "" {
-				ips, _, err := c.ProjectService.List(projectID, nil)
-				if err != nil {
-					return errors.Wrap(err, "Could not list Project IP addresses")
-				}
-
-				data := make([][]string, len(ips))
-
-				for i, ip := range ips {
-					code := ""
-					if ip.Facility != nil {
-						code = ip.Facility.Code
-					}
-					data[i] = []string{ip.ID, ip.Address, code, strconv.FormatBool(ip.Public), ip.Created}
-				}
-				header := []string{"ID", "Address", "Facility", "Public", "Created"}
-
-				return c.Out.Output(ips, header, &data)
 			}
 
-			return fmt.Errorf("Either project-id or assignment-id or reservation-id must be set.")
+			ips, _, err := c.ProjectService.List(projectID, nil)
+			if err != nil {
+				return errors.Wrap(err, "Could not list Project IP addresses")
+			}
+
+			data := make([][]string, len(ips))
+
+			for i, ip := range ips {
+				code := ""
+				if ip.Facility != nil {
+					code = ip.Facility.Code
+				}
+				data[i] = []string{ip.ID, ip.Address, code, strconv.FormatBool(ip.Public), ip.Created}
+			}
+			header := []string{"ID", "Address", "Facility", "Public", "Created"}
+
+			return c.Out.Output(ips, header, &data)
 		},
 	}
 

--- a/internal/ips/unassign.go
+++ b/internal/ips/unassign.go
@@ -39,6 +39,7 @@ metal ip unassign --id [assignment-UUID]
 
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			_, err := c.DeviceService.Unassign(assignmentID)
 			if err != nil {
 				return errors.Wrap(err, "Could not unassign IP address")

--- a/internal/metros/retrieve.go
+++ b/internal/metros/retrieve.go
@@ -37,6 +37,7 @@ metal metros get
 	
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			metros, _, err := c.Service.List(c.Servicer.ListOptions(nil, nil))
 			if err != nil {
 				return errors.Wrap(err, "Could not list Metros")

--- a/internal/organizations/create.go
+++ b/internal/organizations/create.go
@@ -45,6 +45,7 @@ metal organization create -n [name]
 
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			req := &packngo.OrganizationCreateRequest{
 				Name: name,
 			}

--- a/internal/organizations/delete.go
+++ b/internal/organizations/delete.go
@@ -53,6 +53,7 @@ metal organization delete -i [organization_UUID]
 
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			if !force {
 				prompt := promptui.Prompt{
 					Label:     fmt.Sprintf("Are you sure you want to delete organization %s: ", organizationID),

--- a/internal/organizations/payment.go
+++ b/internal/organizations/payment.go
@@ -38,6 +38,7 @@ metal organization payment-methods --id [organization_UUID]
 
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			paymentMethods, _, err := c.Service.ListPaymentMethods(organizationID)
 			if err != nil {
 				return errors.Wrap(err, "Could not list Payment Methods")

--- a/internal/organizations/retrieve.go
+++ b/internal/organizations/retrieve.go
@@ -43,6 +43,7 @@ metal organization get -i [organization-id]
 
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			listOpts := c.Servicer.ListOptions(nil, nil)
 			if organizationID == "" {
 				orgs, _, err := c.Service.List(listOpts)

--- a/internal/organizations/update.go
+++ b/internal/organizations/update.go
@@ -38,6 +38,7 @@ metal organization update --id [organization_UUID] --name [new_name]
 
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			req := &packngo.OrganizationUpdateRequest{}
 
 			if name != "" {

--- a/internal/os/retrieve.go
+++ b/internal/os/retrieve.go
@@ -33,6 +33,7 @@ func (c *Client) Retrieve() *cobra.Command {
 		Long: `Example:
   metal operating-systems get`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			oss, _, err := c.Service.List()
 			if err != nil {
 				return errors.Wrap(err, "Could not list OperatingSystems")

--- a/internal/plans/retrieve.go
+++ b/internal/plans/retrieve.go
@@ -36,6 +36,7 @@ func (c *Client) Retrieve() *cobra.Command {
   
   `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			plans, _, err := c.Service.List(c.Servicer.ListOptions(nil, nil))
 			if err != nil {
 				return errors.Wrap(err, "Could not list Plans")

--- a/internal/projects/create.go
+++ b/internal/projects/create.go
@@ -43,6 +43,7 @@ metal project create --name [project_name]
   
   `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			req := packngo.ProjectCreateRequest{
 				Name: name,
 			}

--- a/internal/projects/delete.go
+++ b/internal/projects/delete.go
@@ -51,6 +51,7 @@ metal project delete --id [project_UUID]
 
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			if !force {
 				prompt := promptui.Prompt{
 					Label:     fmt.Sprintf("Are you sure you want to delete project %s: ", projectID),

--- a/internal/projects/retrieve.go
+++ b/internal/projects/retrieve.go
@@ -48,6 +48,7 @@ metal project get -n [project_name]
 When using "--json" or "--yaml", "--include=members" is implied.
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			if projectID != "" && projectName != "" {
 				return fmt.Errorf("Must specify only one of project-id and project name")
 			}

--- a/internal/projects/update.go
+++ b/internal/projects/update.go
@@ -38,6 +38,7 @@ metal project update --id [project_UUID] --name [new_name]
 
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			req := &packngo.ProjectUpdateRequest{}
 			if name != "" {
 				req.Name = &name

--- a/internal/ssh/create.go
+++ b/internal/ssh/create.go
@@ -41,6 +41,7 @@ metal ssh-key create --key [public_key] --label [label]
 
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			req := packngo.SSHKeyCreateRequest{
 				Label: label,
 				Key:   key,

--- a/internal/ssh/delete.go
+++ b/internal/ssh/delete.go
@@ -51,6 +51,7 @@ metal ssh-key delete --id [ssh-key_UUID]
 
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			if !force {
 				prompt := promptui.Prompt{
 					Label:     fmt.Sprintf("Are you sure you want to delete SSH Key %s: ", sshKeyID),

--- a/internal/ssh/retrieve.go
+++ b/internal/ssh/retrieve.go
@@ -46,6 +46,7 @@ metal ssh-key get --id [ssh-key_UUID]
 
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			if sshKeyID == "" {
 				sshKeys, _, err := c.Service.List()
 				if err != nil {

--- a/internal/ssh/update.go
+++ b/internal/ssh/update.go
@@ -38,6 +38,7 @@ metal ssh-key update --id [ssh-key_UUID] --key [new_key]
 
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			req := &packngo.SSHKeyUpdateRequest{}
 			if key != "" {
 				req.Key = &key

--- a/internal/twofa/disable2fa.go
+++ b/internal/twofa/disable2fa.go
@@ -47,7 +47,10 @@ metal 2fa disable -a -c [code]
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if sms == app {
 				return fmt.Errorf("Either sms or app should be set")
-			} else if sms {
+			}
+
+			cmd.SilenceUsage = true
+			if sms {
 				_, err := c.Service.DisableSms(token)
 				if err != nil {
 					return errors.Wrap(err, "Could not disable Two-Factor Authentication via SMS")

--- a/internal/twofa/enable2fa.go
+++ b/internal/twofa/enable2fa.go
@@ -47,7 +47,10 @@ metal 2fa enable -a -c [code]
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if sms == app {
 				return fmt.Errorf("Either sms or app should be set")
-			} else if sms {
+			}
+
+			cmd.SilenceUsage = true
+			if sms {
 				_, err := c.Service.EnableSms(token)
 				if err != nil {
 					return errors.Wrap(err, "Could not enable Two-Factor Authentication")

--- a/internal/twofa/receive.go
+++ b/internal/twofa/receive.go
@@ -48,6 +48,7 @@ metal 2fa receive -a
 				return fmt.Errorf("Either sms or app should be set")
 			}
 
+			cmd.SilenceUsage = true
 			if sms {
 				_, err := c.Service.ReceiveSms()
 				if err != nil {

--- a/internal/users/retrieve.go
+++ b/internal/users/retrieve.go
@@ -45,6 +45,7 @@ metal user get --id [user_UUID]
 
   `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			var err error
 			var user *packngo.User
 			if userID == "" {

--- a/internal/vlan/create.go
+++ b/internal/vlan/create.go
@@ -42,6 +42,7 @@ metal virtual-network create --project-id [project_UUID] { --metro [metro_code] 
 
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			req := &packngo.VirtualNetworkCreateRequest{
 				ProjectID: projectID,
 				Metro:     metro,

--- a/internal/vlan/delete.go
+++ b/internal/vlan/delete.go
@@ -53,6 +53,7 @@ metal virtual-network delete -i [virtual_network_UUID]
 
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			if !force {
 				prompt := promptui.Prompt{
 					Label:     fmt.Sprintf("Are you sure you want to delete virtual network %s", vnetID),

--- a/internal/vlan/retrieve.go
+++ b/internal/vlan/retrieve.go
@@ -41,6 +41,7 @@ metal virtual-network get -p [project_UUID]
 
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			vnets, _, err := c.Service.List(projectID, c.Servicer.ListOptions(nil, nil))
 			if err != nil {
 				return errors.Wrap(err, "Could not list Project Virtual Networks")


### PR DESCRIPTION
Silence usage errors to make API errors more apparent.  Currently, the API Usage messages can easily hide API errors.


See https://github.com/spf13/cobra/issues/340#issuecomment-374617413 for implementation alternatives. The linked comment is the approach that I found to be most effective.

A few functions were refactored to get usage validation out of the way before silencing usage rendering and executing API commands. Some of these functions had condition branches that could be logically hoisted out of `else` conditions.

Before:
   ```
   $ go run ./cmd/metal/main.go  capacity check --metro xy -P c3.small  -q 1
Error: Could not check capacity: POST https://api.equinix.com/metal/v1/capacity/metros: 422 Metro xy is invalid
  Usage:
  metal capacity check [flags]
   ... 20 more lines of text
   ```

and  After:
   ```
   $ go run ./cmd/metal/main.go  capacity check --metro xy -P c3.small  -q 1
Error: Could not check capacity: POST https://api.equinix.com/metal/v1/capacity/metros: 422 Metro xy is invalid 
   ```

When invalid argument combinations are offered, the usage text is rendered.

```
$ go run ./cmd/metal/main.go  capacity check --metro xy -P c3.small 
Error: required flag(s) "quantity" not set
Usage:
  metal capacity check [flags]
```