### PR TITLE
Updating the Docs - VLANs

### DIFF
--- a/docs/metal.md
+++ b/docs/metal.md
@@ -10,10 +10,10 @@ Command line interface for Equinix Metal
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
   -h, --help                 help for metal
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
@@ -41,5 +41,5 @@ Command line interface for Equinix Metal
 * [metal project](metal_project.md)	 - Project operations
 * [metal ssh-key](metal_ssh-key.md)	 - SSH key operations
 * [metal user](metal_user.md)	 - User operations
-* [metal virtual-network](metal_virtual-network.md)	 - Virtual network operations
+* [metal virtual-network](metal_virtual-network.md)	 - Virtual network (VLAN) operations
 

--- a/docs/metal.md
+++ b/docs/metal.md
@@ -41,5 +41,5 @@ Command line interface for Equinix Metal
 * [metal project](metal_project.md)	 - Project operations
 * [metal ssh-key](metal_ssh-key.md)	 - SSH key operations
 * [metal user](metal_user.md)	 - User operations
-* [metal virtual-network](metal_virtual-network.md)	 - Virtual network (VLAN) operations
+* [metal virtual-network](metal_virtual-network.md)	 - Virtual network (VLAN) operations. For more information on how VLANs work in Equinix Metal, visit https://metal.equinix.com/developers/docs/layer2-networking/vlans/.
 

--- a/docs/metal_2fa.md
+++ b/docs/metal_2fa.md
@@ -16,9 +16,9 @@ Two Factor Authentication operations: enable, disable, receive
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_2fa_disable.md
+++ b/docs/metal_2fa_disable.md
@@ -30,9 +30,9 @@ metal 2fa disable [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_2fa_enable.md
+++ b/docs/metal_2fa_enable.md
@@ -30,9 +30,9 @@ metal 2fa enable [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_2fa_receive.md
+++ b/docs/metal_2fa_receive.md
@@ -29,9 +29,9 @@ metal 2fa receive [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_capacity.md
+++ b/docs/metal_capacity.md
@@ -16,9 +16,9 @@ Capacities operations: get, check
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_capacity_check.md
+++ b/docs/metal_capacity_check.md
@@ -26,9 +26,9 @@ metal capacity check -m sv,ny,da -P c3.large.arm,c3.medium.x86 -q 10
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_capacity_get.md
+++ b/docs/metal_capacity_get.md
@@ -27,9 +27,9 @@ metal capacity get -m sv,ny,da -P c3.large.arm,c3.medium.x86
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_completion.md
+++ b/docs/metal_completion.md
@@ -49,9 +49,9 @@ metal completion [bash|zsh|fish|powershell]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_device.md
+++ b/docs/metal_device.md
@@ -16,9 +16,9 @@ Device operations: create, delete, update, start/stop, reboot and get.
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_device_create.md
+++ b/docs/metal_device_create.md
@@ -42,9 +42,9 @@ metal device create [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_device_delete.md
+++ b/docs/metal_device_delete.md
@@ -26,9 +26,9 @@ metal device delete [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_device_get.md
+++ b/docs/metal_device_get.md
@@ -26,9 +26,9 @@ metal device get [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_device_reboot.md
+++ b/docs/metal_device_reboot.md
@@ -25,9 +25,9 @@ metal device reboot [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_device_start.md
+++ b/docs/metal_device_start.md
@@ -25,9 +25,9 @@ metal device start [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_device_stop.md
+++ b/docs/metal_device_stop.md
@@ -25,9 +25,9 @@ metal device stop [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_device_update.md
+++ b/docs/metal_device_update.md
@@ -33,9 +33,9 @@ metal device update [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_docs.md
+++ b/docs/metal_docs.md
@@ -20,9 +20,9 @@ metal docs [DESTINATION]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_env.md
+++ b/docs/metal_env.md
@@ -38,9 +38,9 @@ metal env
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_event.md
+++ b/docs/metal_event.md
@@ -16,9 +16,9 @@ Events operations: get
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_event_get.md
+++ b/docs/metal_event_get.md
@@ -44,9 +44,9 @@ metal event get [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_facilities.md
+++ b/docs/metal_facilities.md
@@ -16,9 +16,9 @@ Facility operations: get
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_facilities_get.md
+++ b/docs/metal_facilities_get.md
@@ -24,9 +24,9 @@ metal facilities get [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_hardware-reservation.md
+++ b/docs/metal_hardware-reservation.md
@@ -16,9 +16,9 @@ Hardware reservation operations: get, move
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_hardware-reservation_get.md
+++ b/docs/metal_hardware-reservation_get.md
@@ -28,9 +28,9 @@ metal hardware-reservation get [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_hardware-reservation_move.md
+++ b/docs/metal_hardware-reservation_move.md
@@ -25,9 +25,9 @@ metal hardware-reservation move [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_init.md
+++ b/docs/metal_init.md
@@ -34,9 +34,9 @@ metal init
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ip.md
+++ b/docs/metal_ip.md
@@ -16,9 +16,9 @@ IP address, reservations and assignment operations: assign, unassign, remove, av
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ip_assign.md
+++ b/docs/metal_ip_assign.md
@@ -26,9 +26,9 @@ metal ip assign [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ip_available.md
+++ b/docs/metal_ip_available.md
@@ -26,9 +26,9 @@ metal ip available [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ip_get.md
+++ b/docs/metal_ip_get.md
@@ -37,9 +37,9 @@ metal ip get [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ip_remove.md
+++ b/docs/metal_ip_remove.md
@@ -25,9 +25,9 @@ metal ip remove [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ip_request.md
+++ b/docs/metal_ip_request.md
@@ -30,9 +30,9 @@ metal ip request [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ip_unassign.md
+++ b/docs/metal_ip_unassign.md
@@ -25,9 +25,9 @@ metal ip unassign [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_metros.md
+++ b/docs/metal_metros.md
@@ -16,9 +16,9 @@ Metro operations: get
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_metros_get.md
+++ b/docs/metal_metros_get.md
@@ -24,9 +24,9 @@ metal metros get [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_operating-systems.md
+++ b/docs/metal_operating-systems.md
@@ -16,9 +16,9 @@ Operating system operations: get
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_operating-systems_get.md
+++ b/docs/metal_operating-systems_get.md
@@ -21,9 +21,9 @@ metal operating-systems get [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_organization.md
+++ b/docs/metal_organization.md
@@ -16,9 +16,9 @@ Organization operations: create, update, delete and get
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_organization_create.md
+++ b/docs/metal_organization_create.md
@@ -29,9 +29,9 @@ metal organization create [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_organization_delete.md
+++ b/docs/metal_organization_delete.md
@@ -26,9 +26,9 @@ metal organization delete [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_organization_get.md
+++ b/docs/metal_organization_get.md
@@ -29,9 +29,9 @@ metal organization get [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_organization_payment-methods.md
+++ b/docs/metal_organization_payment-methods.md
@@ -25,9 +25,9 @@ metal organization payment-methods [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_organization_update.md
+++ b/docs/metal_organization_update.md
@@ -30,9 +30,9 @@ metal organization update [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_plan.md
+++ b/docs/metal_plan.md
@@ -16,9 +16,9 @@ Plan operations: get
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_plan_get.md
+++ b/docs/metal_plan_get.md
@@ -24,9 +24,9 @@ metal plan get [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_project.md
+++ b/docs/metal_project.md
@@ -16,9 +16,9 @@ Project operations: create, delete, update and get
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_project_create.md
+++ b/docs/metal_project_create.md
@@ -27,9 +27,9 @@ metal project create [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_project_delete.md
+++ b/docs/metal_project_delete.md
@@ -26,9 +26,9 @@ metal project delete [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_project_get.md
+++ b/docs/metal_project_get.md
@@ -32,9 +32,9 @@ metal project get [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_project_update.md
+++ b/docs/metal_project_update.md
@@ -27,9 +27,9 @@ metal project update [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ssh-key.md
+++ b/docs/metal_ssh-key.md
@@ -16,9 +16,9 @@ SSH key operations: create, delete, update and get
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ssh-key_create.md
+++ b/docs/metal_ssh-key_create.md
@@ -26,9 +26,9 @@ metal ssh-key create [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ssh-key_delete.md
+++ b/docs/metal_ssh-key_delete.md
@@ -26,9 +26,9 @@ metal ssh-key delete [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ssh-key_get.md
+++ b/docs/metal_ssh-key_get.md
@@ -29,9 +29,9 @@ metal ssh-key get [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ssh-key_update.md
+++ b/docs/metal_ssh-key_update.md
@@ -27,9 +27,9 @@ metal ssh-key update [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_user.md
+++ b/docs/metal_user.md
@@ -16,9 +16,9 @@ User operations: get
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_user_get.md
+++ b/docs/metal_user_get.md
@@ -29,9 +29,9 @@ metal user get [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_virtual-network.md
+++ b/docs/metal_virtual-network.md
@@ -1,10 +1,10 @@
 ## metal virtual-network
 
-Virtual network (VLAN) operations
+Virtual network (VLAN) operations. For more information on how VLANs work in Equinix Metal, visit https://metal.equinix.com/developers/docs/layer2-networking/vlans/.
 
 ### Synopsis
 
-Virtual network (VLAN) operations : create, get, delete
+Virtual network (VLAN) operations : create, get, delete.
 
 ### Options
 

--- a/docs/metal_virtual-network.md
+++ b/docs/metal_virtual-network.md
@@ -29,7 +29,7 @@ Virtual network operations: create, delete and get
 ### SEE ALSO
 
 * [metal](metal.md)	 - Command line interface for Equinix Metal
-* [metal virtual-network create](metal_virtual-network_create.md)	 - Creates a virtual network
+* [metal virtual-network create](metal_virtual-network_create.md)	 - Creates a virtual network.
 * [metal virtual-network delete](metal_virtual-network_delete.md)	 - Deletes a Virtual Network
 * [metal virtual-network get](metal_virtual-network_get.md)	 - Retrieves a list of virtual networks for a single project.
 

--- a/docs/metal_virtual-network.md
+++ b/docs/metal_virtual-network.md
@@ -1,10 +1,10 @@
 ## metal virtual-network
 
-Virtual network operations
+Virtual network (VLAN) operations
 
 ### Synopsis
 
-Virtual network operations: create, delete and get
+Virtual network (VLAN) operations : create, get, delete
 
 ### Options
 
@@ -16,9 +16,9 @@ Virtual network operations: create, delete and get
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
@@ -30,6 +30,6 @@ Virtual network operations: create, delete and get
 
 * [metal](metal.md)	 - Command line interface for Equinix Metal
 * [metal virtual-network create](metal_virtual-network_create.md)	 - Creates a virtual network.
-* [metal virtual-network delete](metal_virtual-network_delete.md)	 - Deletes a Virtual Network
-* [metal virtual-network get](metal_virtual-network_get.md)	 - Retrieves a list of virtual networks for a single project.
+* [metal virtual-network delete](metal_virtual-network_delete.md)	 - Deletes a virtual network.
+* [metal virtual-network get](metal_virtual-network_get.md)	 - Lists virtual networks.
 

--- a/docs/metal_virtual-network_create.md
+++ b/docs/metal_virtual-network_create.md
@@ -1,17 +1,24 @@
 ## metal virtual-network create
 
-Creates a virtual network
+Creates a virtual network.
 
 ### Synopsis
 
-Example:
-
-metal virtual-network create --project-id [project_UUID] { --metro [metro_code] --vlan [vlan] | --facility [facility_code] }
-
-
+Creates a VLAN in the specified project. If you are creating a VLAN in a metro, you can optionally specify the VXLAN ID. If you are creating a VLAN in a facility, the VXLAN ID is auto-assigned.
 
 ```
 metal virtual-network create [flags]
+```
+
+### Examples
+
+```
+# Creates a VLAN with vxlan ID 1999 in the Dallas metro:
+metal virtual-network create -p <METAL_PROJECT_ID> -m da -vxlan 1999
+		
+# Creates a VLAN with vxlan ID 1999 in the Dallas metro:
+metal virtual-network create -p <METAL_PROJECT_ID> -m da -vxlan 1999
+
 ```
 
 ### Options
@@ -22,7 +29,7 @@ metal virtual-network create [flags]
   -h, --help                 help for create
   -m, --metro string         Code of the metro
   -p, --project-id string    Project ID (METAL_PROJECT_ID)
-      --vxlan int            VXLAN id to use (can only be used with --metro)
+      --vxlan int            Optional VXLAN ID. Must be between 2 and 3999 and can only be used with --metro.
 ```
 
 ### Options inherited from parent commands

--- a/docs/metal_virtual-network_create.md
+++ b/docs/metal_virtual-network_create.md
@@ -4,7 +4,7 @@ Creates a virtual network.
 
 ### Synopsis
 
-Creates a VLAN in the specified project. If you are creating a VLAN in a metro, you can optionally specify the VXLAN ID. If you are creating a VLAN in a facility, the VXLAN ID is auto-assigned.
+Creates a VLAN in the specified project. If you are creating a VLAN in a metro, you can optionally specify the VXLAN ID otherwise it is auto-assigned. If you are creating a VLAN in a facility, the VXLAN ID is auto-assigned.
 
 ```
 metal virtual-network create -p <project_UUID>  [-m <metro_code> -vxlan <vlan> | -f <facility_code>] [-d <description>] [flags]
@@ -14,10 +14,7 @@ metal virtual-network create -p <project_UUID>  [-m <metro_code> -vxlan <vlan> |
 
 ```
   # Creates a VLAN with vxlan ID 1999 in the Dallas metro:
-  metal virtual-network create -p <METAL_PROJECT_ID> -m da -vxlan 1999
-
-  # Creates a VLAN with an auto-assigned vxlan ID in the Dallas metro:
-  metal virtual-network create -p <METAL_PROJECT_ID> -m da
+  metal virtual-network create -p <METAL_PROJECT_ID> -m da --vxlan 1999
 
   # Creates a VLAN in the sjc1 facility
   metal virtual-network create -p <METAL_PROJECT_ID> -f sjc1
@@ -50,5 +47,5 @@ metal virtual-network create -p <project_UUID>  [-m <metro_code> -vxlan <vlan> |
 
 ### SEE ALSO
 
-* [metal virtual-network](metal_virtual-network.md)	 - Virtual network (VLAN) operations
+* [metal virtual-network](metal_virtual-network.md)	 - Virtual network (VLAN) operations. For more information on how VLANs work in Equinix Metal, visit https://metal.equinix.com/developers/docs/layer2-networking/vlans/.
 

--- a/docs/metal_virtual-network_create.md
+++ b/docs/metal_virtual-network_create.md
@@ -7,7 +7,7 @@ Creates a virtual network.
 Creates a VLAN in the specified project. If you are creating a VLAN in a metro, you can optionally specify the VXLAN ID. If you are creating a VLAN in a facility, the VXLAN ID is auto-assigned.
 
 ```
-metal virtual-network create [flags]
+metal virtual-network create -p <project_UUID>  [-m <metro_code> -vxlan <vlan> | -f <facility_code>] [-d <description>] [global_options] [flags]
 ```
 
 ### Examples
@@ -16,8 +16,11 @@ metal virtual-network create [flags]
 # Creates a VLAN with vxlan ID 1999 in the Dallas metro:
 metal virtual-network create -p <METAL_PROJECT_ID> -m da -vxlan 1999
 		
-# Creates a VLAN with vxlan ID 1999 in the Dallas metro:
-metal virtual-network create -p <METAL_PROJECT_ID> -m da -vxlan 1999
+# Creates a VLAN with an auto-assigned vxlan ID in the Dallas metro:
+metal virtual-network create -p <METAL_PROJECT_ID> -m da
+
+# Creates a VLAN in the sjc1 facility
+metal virtual-network create -p <METAL_PROJECT_ID> -f sjc1
 
 ```
 

--- a/docs/metal_virtual-network_create.md
+++ b/docs/metal_virtual-network_create.md
@@ -27,10 +27,10 @@ metal virtual-network create -p <METAL_PROJECT_ID> -f sjc1
 ### Options
 
 ```
-  -d, --description string   Description of the virtual network
-  -f, --facility string      Code of the facility
+  -d, --description string   A user-friendly description of the virtual network.
+  -f, --facility string      Code of the facility.
   -h, --help                 help for create
-  -m, --metro string         Code of the metro
+  -m, --metro string         Code of the metro.
   -p, --project-id string    Project ID (METAL_PROJECT_ID)
       --vxlan int            Optional VXLAN ID. Must be between 2 and 3999 and can only be used with --metro.
 ```
@@ -39,9 +39,9 @@ metal virtual-network create -p <METAL_PROJECT_ID> -f sjc1
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
@@ -51,5 +51,5 @@ metal virtual-network create -p <METAL_PROJECT_ID> -f sjc1
 
 ### SEE ALSO
 
-* [metal virtual-network](metal_virtual-network.md)	 - Virtual network operations
+* [metal virtual-network](metal_virtual-network.md)	 - Virtual network (VLAN) operations
 

--- a/docs/metal_virtual-network_create.md
+++ b/docs/metal_virtual-network_create.md
@@ -14,10 +14,10 @@ metal virtual-network create -p <project_UUID>  [-m <metro_code> -vxlan <vlan> |
 
 ```
   # Creates a VLAN with vxlan ID 1999 in the Dallas metro:
-  metal virtual-network create -p <METAL_PROJECT_ID> -m da --vxlan 1999
+  metal virtual-network create -p $METAL_PROJECT_ID -m da --vxlan 1999
 
   # Creates a VLAN in the sjc1 facility
-  metal virtual-network create -p <METAL_PROJECT_ID> -f sjc1
+  metal virtual-network create -p $METAL_PROJECT_ID -f sjc1
 ```
 
 ### Options

--- a/docs/metal_virtual-network_create.md
+++ b/docs/metal_virtual-network_create.md
@@ -7,21 +7,20 @@ Creates a virtual network.
 Creates a VLAN in the specified project. If you are creating a VLAN in a metro, you can optionally specify the VXLAN ID. If you are creating a VLAN in a facility, the VXLAN ID is auto-assigned.
 
 ```
-metal virtual-network create -p <project_UUID>  [-m <metro_code> -vxlan <vlan> | -f <facility_code>] [-d <description>] [global_options] [flags]
+metal virtual-network create -p <project_UUID>  [-m <metro_code> -vxlan <vlan> | -f <facility_code>] [-d <description>] [flags]
 ```
 
 ### Examples
 
 ```
-# Creates a VLAN with vxlan ID 1999 in the Dallas metro:
-metal virtual-network create -p <METAL_PROJECT_ID> -m da -vxlan 1999
-		
-# Creates a VLAN with an auto-assigned vxlan ID in the Dallas metro:
-metal virtual-network create -p <METAL_PROJECT_ID> -m da
+  # Creates a VLAN with vxlan ID 1999 in the Dallas metro:
+  metal virtual-network create -p <METAL_PROJECT_ID> -m da -vxlan 1999
 
-# Creates a VLAN in the sjc1 facility
-metal virtual-network create -p <METAL_PROJECT_ID> -f sjc1
+  # Creates a VLAN with an auto-assigned vxlan ID in the Dallas metro:
+  metal virtual-network create -p <METAL_PROJECT_ID> -m da
 
+  # Creates a VLAN in the sjc1 facility
+  metal virtual-network create -p <METAL_PROJECT_ID> -f sjc1
 ```
 
 ### Options
@@ -31,7 +30,7 @@ metal virtual-network create -p <METAL_PROJECT_ID> -f sjc1
   -f, --facility string      Code of the facility.
   -h, --help                 help for create
   -m, --metro string         Code of the metro.
-  -p, --project-id string    Project ID (METAL_PROJECT_ID)
+  -p, --project-id string    The project's UUID. This flag is required, unless specified in the config created by metal init or set as METAL_PROJECT_ID environment variable.
       --vxlan int            Optional VXLAN ID. Must be between 2 and 3999 and can only be used with --metro.
 ```
 

--- a/docs/metal_virtual-network_delete.md
+++ b/docs/metal_virtual-network_delete.md
@@ -7,20 +7,19 @@ Deletes a virtual network.
 Deletes the specified VLAN with a confirmation prompt. To skip the confirmation use --force. You are not able to delete a VLAN that is attached to any ports.
 
 ```
-metal virtual-network delete -i <virtual_network_UUID> [-f] [global_options] [flags]
+metal virtual-network delete -i <virtual_network_UUID> [-f] [flags]
 ```
 
 ### Examples
 
 ```
-# Deletes a VLAN, with confirmation.
-metal virtual-network delete -i 77e6d57a-d7a4-4816-b451-cf9b043444e2
->
-✔ Are you sure you want to delete virtual network 77e6d57a-d7a4-4816-b451-cf9b043444e2: y
+  # Deletes a VLAN, with confirmation.
+  metal virtual-network delete -i 77e6d57a-d7a4-4816-b451-cf9b043444e2
+  >
+  ✔ Are you sure you want to delete virtual network 77e6d57a-d7a4-4816-b451-cf9b043444e2: y
 		
-# Deletes a VLAN, skipping confirmation.
-metal virtual-network delete -f -i 77e6d57a-d7a4-4816-b451-cf9b043444e2
-
+  # Deletes a VLAN, skipping confirmation.
+  metal virtual-network delete -f -i 77e6d57a-d7a4-4816-b451-cf9b043444e2
 ```
 
 ### Options

--- a/docs/metal_virtual-network_delete.md
+++ b/docs/metal_virtual-network_delete.md
@@ -46,5 +46,5 @@ metal virtual-network delete -i <virtual_network_UUID> [-f] [flags]
 
 ### SEE ALSO
 
-* [metal virtual-network](metal_virtual-network.md)	 - Virtual network (VLAN) operations
+* [metal virtual-network](metal_virtual-network.md)	 - Virtual network (VLAN) operations. For more information on how VLANs work in Equinix Metal, visit https://metal.equinix.com/developers/docs/layer2-networking/vlans/.
 

--- a/docs/metal_virtual-network_delete.md
+++ b/docs/metal_virtual-network_delete.md
@@ -1,34 +1,43 @@
 ## metal virtual-network delete
 
-Deletes a Virtual Network
+Deletes a virtual network.
 
 ### Synopsis
 
-Example:
-
-metal virtual-network delete -i [virtual_network_UUID]
-
-	
+Deletes the specified VLAN with a confirmation prompt. To skip the confirmation use --force. You are not able to delete a VLAN that is attached to any ports.
 
 ```
-metal virtual-network delete [flags]
+metal virtual-network delete -i <virtual_network_UUID> [-f] [global_options] [flags]
+```
+
+### Examples
+
+```
+# Deletes a VLAN, with confirmation.
+metal virtual-network delete -i 77e6d57a-d7a4-4816-b451-cf9b043444e2
+>
+✔ Are you sure you want to delete virtual network 77e6d57a-d7a4-4816-b451-cf9b043444e2: y
+		
+# Deletes a VLAN, skipping confirmation.
+metal virtual-network delete -f -i 77e6d57a-d7a4-4816-b451-cf9b043444e2
+
 ```
 
 ### Options
 
 ```
-  -f, --force       Force removal of the virtual network
+  -f, --force       Skips confirmation for the removal of the virtual network.
   -h, --help        help for delete
-  -i, --id string   UUID of the vlan
+  -i, --id string   UUID of the VLAN.
 ```
 
 ### Options inherited from parent commands
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
@@ -38,5 +47,5 @@ metal virtual-network delete [flags]
 
 ### SEE ALSO
 
-* [metal virtual-network](metal_virtual-network.md)	 - Virtual network operations
+* [metal virtual-network](metal_virtual-network.md)	 - Virtual network (VLAN) operations
 

--- a/docs/metal_virtual-network_get.md
+++ b/docs/metal_virtual-network_get.md
@@ -7,22 +7,22 @@ Lists virtual networks.
 Retrieves a list of virtual networks for the specified project.
 
 ```
-metal virtual-network get -p <project_UUID> [global_options] [flags]
+metal virtual-network get -p <project_UUID> [flags]
 ```
 
 ### Examples
 
 ```
-# Lists virtual networks for project 3b0795ba-ec9a-4a9e-83a7-043e7e11407c:
-virtual-network get -p 3b0795ba-ec9a-4a9e-83a7-043e7e11407c
 
+  # Lists virtual networks for project 3b0795ba-ec9a-4a9e-83a7-043e7e11407c:
+  virtual-network get -p 3b0795ba-ec9a-4a9e-83a7-043e7e11407c
 ```
 
 ### Options
 
 ```
   -h, --help                help for get
-  -p, --project-id string   Project ID (METAL_PROJECT_ID)
+  -p, --project-id string   The project's UUID. This flag is required, unless specified in the config created by metal init or set as METAL_PROJECT_ID environment variable.
 ```
 
 ### Options inherited from parent commands

--- a/docs/metal_virtual-network_get.md
+++ b/docs/metal_virtual-network_get.md
@@ -15,7 +15,7 @@ metal virtual-network get -p <project_UUID> [flags]
 ```
 
   # Lists virtual networks for project 3b0795ba-ec9a-4a9e-83a7-043e7e11407c:
-  virtual-network get -p 3b0795ba-ec9a-4a9e-83a7-043e7e11407c
+  metal virtual-network get -p 3b0795ba-ec9a-4a9e-83a7-043e7e11407c
 ```
 
 ### Options

--- a/docs/metal_virtual-network_get.md
+++ b/docs/metal_virtual-network_get.md
@@ -4,7 +4,7 @@ Lists virtual networks.
 
 ### Synopsis
 
-Retrieves a list of virtual networks for the specified project.
+Retrieves a list of all VLANs for the specified project.
 
 ```
 metal virtual-network get -p <project_UUID> [flags]
@@ -41,5 +41,5 @@ metal virtual-network get -p <project_UUID> [flags]
 
 ### SEE ALSO
 
-* [metal virtual-network](metal_virtual-network.md)	 - Virtual network (VLAN) operations
+* [metal virtual-network](metal_virtual-network.md)	 - Virtual network (VLAN) operations. For more information on how VLANs work in Equinix Metal, visit https://metal.equinix.com/developers/docs/layer2-networking/vlans/.
 

--- a/docs/metal_virtual-network_get.md
+++ b/docs/metal_virtual-network_get.md
@@ -1,17 +1,21 @@
 ## metal virtual-network get
 
-Retrieves a list of virtual networks for a single project.
+Lists virtual networks.
 
 ### Synopsis
 
-Example:
-
-metal virtual-network get -p [project_UUID]
-
-	
+Retrieves a list of virtual networks for the specified project.
 
 ```
-metal virtual-network get [flags]
+metal virtual-network get -p <project_UUID> [global_options] [flags]
+```
+
+### Examples
+
+```
+# Lists virtual networks for project 3b0795ba-ec9a-4a9e-83a7-043e7e11407c:
+virtual-network get -p 3b0795ba-ec9a-4a9e-83a7-043e7e11407c
+
 ```
 
 ### Options
@@ -25,9 +29,9 @@ metal virtual-network get [flags]
 
 ```
       --config string        Path to JSON or YAML configuration file
-      --exclude strings      Comma seperated Href references to collapse in results, may be dotted three levels deep
+      --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
-      --include strings      Comma seperated Href references to expand in results, may be dotted three levels deep
+      --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
   -o, --output string        Output format (*table, json, yaml)
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
@@ -37,5 +41,5 @@ metal virtual-network get [flags]
 
 ### SEE ALSO
 
-* [metal virtual-network](metal_virtual-network.md)	 - Virtual network operations
+* [metal virtual-network](metal_virtual-network.md)	 - Virtual network (VLAN) operations
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/equinix/metal-cli
 go 1.16
 
 require (
+	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/equinix/metal-cli
 go 1.16
 
 require (
-	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
-github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -194,8 +194,8 @@ func (c *Client) NewCommand() *cobra.Command {
 	rootCmd.PersistentFlags().StringVar(&c.cfgFile, "config", c.cfgFile, "Path to JSON or YAML configuration file")
 
 	rootCmd.PersistentFlags().StringVarP(&c.outputFormat, "output", "o", "", "Output format (*table, json, yaml)")
-	c.includes = rootCmd.PersistentFlags().StringSlice("include", nil, "Comma seperated Href references to expand in results, may be dotted three levels deep")
-	c.excludes = rootCmd.PersistentFlags().StringSlice("exclude", nil, "Comma seperated Href references to collapse in results, may be dotted three levels deep")
+	c.includes = rootCmd.PersistentFlags().StringSlice("include", nil, "Comma separated Href references to expand in results, may be dotted three levels deep")
+	c.excludes = rootCmd.PersistentFlags().StringSlice("exclude", nil, "Comma separated Href references to collapse in results, may be dotted three levels deep")
 	c.filters = rootCmd.PersistentFlags().StringArray("filter", nil, "Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.")
 	rootCmd.PersistentFlags().StringVar(&c.search, "search", "", "Search keyword for use in 'get' actions. Search is not supported by all resources.")
 	rootCmd.PersistentFlags().StringVar(&c.sortBy, "sort-by", "", "Sort fields for use in 'get' actions. Sort is not supported by all resources.")

--- a/internal/vlan/create.go
+++ b/internal/vlan/create.go
@@ -35,7 +35,7 @@ func (c *Client) Create() *cobra.Command {
 
 	// createVirtualNetworkCmd represents the createVirtualNetwork command
 	var createVirtualNetworkCmd = &cobra.Command{
-		Use:    `create -p <project_UUID>  [-m <metro_code> -vxlan <vlan> | -f <facility_code>] [-d <description>] [global_options]`,
+		Use: `create -p <project_UUID>  [-m <metro_code> -vxlan <vlan> | -f <facility_code>] [-d <description>] [global_options]`,
 		Short: "Creates a virtual network.",
 		Long: "Creates a VLAN in the specified project. If you are creating a VLAN in a metro, you can optionally specify the VXLAN ID. If you are creating a VLAN in a facility, the VXLAN ID is auto-assigned.",
 		Example: heredoc.Doc(`

--- a/internal/vlan/create.go
+++ b/internal/vlan/create.go
@@ -38,10 +38,10 @@ func (c *Client) Create() *cobra.Command {
 		Short: "Creates a virtual network.",
 		Long: "Creates a VLAN in the specified project. If you are creating a VLAN in a metro, you can optionally specify the VXLAN ID otherwise it is auto-assigned. If you are creating a VLAN in a facility, the VXLAN ID is auto-assigned.",
 		Example: `  # Creates a VLAN with vxlan ID 1999 in the Dallas metro:
-  metal virtual-network create -p <METAL_PROJECT_ID> -m da --vxlan 1999
+  metal virtual-network create -p $METAL_PROJECT_ID -m da --vxlan 1999
 
   # Creates a VLAN in the sjc1 facility
-  metal virtual-network create -p <METAL_PROJECT_ID> -f sjc1`,
+  metal virtual-network create -p $METAL_PROJECT_ID -f sjc1`,
 		
 		RunE: func(cmd *cobra.Command, args []string) error {
 			

--- a/internal/vlan/create.go
+++ b/internal/vlan/create.go
@@ -26,7 +26,6 @@ import (
 	"github.com/packethost/packngo"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/MakeNowJust/heredoc"
 )
 
 func (c *Client) Create() *cobra.Command {
@@ -35,19 +34,17 @@ func (c *Client) Create() *cobra.Command {
 
 	// createVirtualNetworkCmd represents the createVirtualNetwork command
 	var createVirtualNetworkCmd = &cobra.Command{
-		Use: `create -p <project_UUID>  [-m <metro_code> -vxlan <vlan> | -f <facility_code>] [-d <description>] [global_options]`,
+		Use: `create -p <project_UUID>  [-m <metro_code> -vxlan <vlan> | -f <facility_code>] [-d <description>]`,
 		Short: "Creates a virtual network.",
 		Long: "Creates a VLAN in the specified project. If you are creating a VLAN in a metro, you can optionally specify the VXLAN ID. If you are creating a VLAN in a facility, the VXLAN ID is auto-assigned.",
-		Example: heredoc.Doc(`
-			# Creates a VLAN with vxlan ID 1999 in the Dallas metro:
-			metal virtual-network create -p <METAL_PROJECT_ID> -m da -vxlan 1999
-		
-			# Creates a VLAN with an auto-assigned vxlan ID in the Dallas metro:
-			metal virtual-network create -p <METAL_PROJECT_ID> -m da
+		Example: `  # Creates a VLAN with vxlan ID 1999 in the Dallas metro:
+  metal virtual-network create -p <METAL_PROJECT_ID> -m da -vxlan 1999
 
-			# Creates a VLAN in the sjc1 facility
-			metal virtual-network create -p <METAL_PROJECT_ID> -f sjc1
-		`),
+  # Creates a VLAN with an auto-assigned vxlan ID in the Dallas metro:
+  metal virtual-network create -p <METAL_PROJECT_ID> -m da
+
+  # Creates a VLAN in the sjc1 facility
+  metal virtual-network create -p <METAL_PROJECT_ID> -f sjc1`,
 		
 		RunE: func(cmd *cobra.Command, args []string) error {
 			
@@ -79,7 +76,7 @@ func (c *Client) Create() *cobra.Command {
 		},
 	}
 
-	createVirtualNetworkCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID (METAL_PROJECT_ID)")
+	createVirtualNetworkCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "The project's UUID. This flag is required, unless specified in the config created by metal init or set as METAL_PROJECT_ID environment variable.")
 	createVirtualNetworkCmd.Flags().StringVarP(&facility, "facility", "f", "", "Code of the facility.")
 	createVirtualNetworkCmd.Flags().StringVarP(&metro, "metro", "m", "", "Code of the metro.")
 	createVirtualNetworkCmd.Flags().StringVarP(&description, "description", "d", "", "A user-friendly description of the virtual network.")

--- a/internal/vlan/create.go
+++ b/internal/vlan/create.go
@@ -26,6 +26,7 @@ import (
 	"github.com/packethost/packngo"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/MakeNowJust/heredoc"
 )
 
 func (c *Client) Create() *cobra.Command {
@@ -34,12 +35,24 @@ func (c *Client) Create() *cobra.Command {
 
 	// createVirtualNetworkCmd represents the createVirtualNetwork command
 	var createVirtualNetworkCmd = &cobra.Command{
-		Use:   `metal virtual-network create -p <project_UUID>  [-m <metro_code> -vxlan <vlan> | -f <facility_code>] [-d <description>] [global_options]`,
+		Use:    `create -p <project_UUID>  [-m <metro_code> -vxlan <vlan> | -f <facility_code>] [-d <description>] [global_options]`,
 		Short: "Creates a virtual network.",
-		Long: "Creates a VLAN in the specified project. If creating a VXLAN in a metro, you can optionally specify the VXLAN ID. If creating a VLAN in a facility, the VXLAN ID is auto-assigned.",
+		Long: "Creates a VLAN in the specified project. If you are creating a VLAN in a metro, you can optionally specify the VXLAN ID. If you are creating a VLAN in a facility, the VXLAN ID is auto-assigned.",
+		Example: heredoc.Doc(`
+			# Creates a VLAN with vxlan ID 1999 in the Dallas metro:
+			metal virtual-network create -p <METAL_PROJECT_ID> -m da -vxlan 1999
+		
+			# Creates a VLAN with an auto-assigned vxlan ID in the Dallas metro:
+			metal virtual-network create -p <METAL_PROJECT_ID> -m da
+
+			# Creates a VLAN in the sjc1 facility
+			metal virtual-network create -p <METAL_PROJECT_ID> -f sjc1
+		`),
 		
 		RunE: func(cmd *cobra.Command, args []string) error {
+			
 			cmd.SilenceUsage = true
+			
 			req := &packngo.VirtualNetworkCreateRequest{
 				ProjectID: projectID,
 				Metro:     metro,

--- a/internal/vlan/create.go
+++ b/internal/vlan/create.go
@@ -34,13 +34,10 @@ func (c *Client) Create() *cobra.Command {
 
 	// createVirtualNetworkCmd represents the createVirtualNetwork command
 	var createVirtualNetworkCmd = &cobra.Command{
-		Use:   "create",
-		Short: "Creates a virtual network",
-		Long: `Example:
-
-metal virtual-network create --project-id [project_UUID] { --metro [metro_code] --vlan [vlan] | --facility [facility_code] }
-
-`,
+		Use:   `metal virtual-network create -p <project_UUID>  [-m <metro_code> -vxlan <vlan> | -f <facility_code>] [-d <description>] [global_options]`,
+		Short: "Creates a virtual network.",
+		Long: "Creates a VLAN in the specified project. If creating a VXLAN in a metro, you can optionally specify the VXLAN ID. If creating a VLAN in a facility, the VXLAN ID is auto-assigned.",
+		
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			req := &packngo.VirtualNetworkCreateRequest{
@@ -73,7 +70,7 @@ metal virtual-network create --project-id [project_UUID] { --metro [metro_code] 
 	createVirtualNetworkCmd.Flags().StringVarP(&facility, "facility", "f", "", "Code of the facility")
 	createVirtualNetworkCmd.Flags().StringVarP(&metro, "metro", "m", "", "Code of the metro")
 	createVirtualNetworkCmd.Flags().StringVarP(&description, "description", "d", "", "Description of the virtual network")
-	createVirtualNetworkCmd.Flags().IntVarP(&vxlan, "vxlan", "", 0, "VXLAN id to use (can only be used with --metro)")
+	createVirtualNetworkCmd.Flags().IntVarP(&vxlan, "vxlan", "", 0, "Optional VXLAN ID. Must be between 2 and 3999 and can only be used with --metro.")
 
 	_ = createVirtualNetworkCmd.MarkFlagRequired("project-id")
 	return createVirtualNetworkCmd

--- a/internal/vlan/create.go
+++ b/internal/vlan/create.go
@@ -36,12 +36,9 @@ func (c *Client) Create() *cobra.Command {
 	var createVirtualNetworkCmd = &cobra.Command{
 		Use: `create -p <project_UUID>  [-m <metro_code> -vxlan <vlan> | -f <facility_code>] [-d <description>]`,
 		Short: "Creates a virtual network.",
-		Long: "Creates a VLAN in the specified project. If you are creating a VLAN in a metro, you can optionally specify the VXLAN ID. If you are creating a VLAN in a facility, the VXLAN ID is auto-assigned.",
+		Long: "Creates a VLAN in the specified project. If you are creating a VLAN in a metro, you can optionally specify the VXLAN ID otherwise it is auto-assigned. If you are creating a VLAN in a facility, the VXLAN ID is auto-assigned.",
 		Example: `  # Creates a VLAN with vxlan ID 1999 in the Dallas metro:
-  metal virtual-network create -p <METAL_PROJECT_ID> -m da -vxlan 1999
-
-  # Creates a VLAN with an auto-assigned vxlan ID in the Dallas metro:
-  metal virtual-network create -p <METAL_PROJECT_ID> -m da
+  metal virtual-network create -p <METAL_PROJECT_ID> -m da --vxlan 1999
 
   # Creates a VLAN in the sjc1 facility
   metal virtual-network create -p <METAL_PROJECT_ID> -f sjc1`,

--- a/internal/vlan/create.go
+++ b/internal/vlan/create.go
@@ -80,9 +80,9 @@ func (c *Client) Create() *cobra.Command {
 	}
 
 	createVirtualNetworkCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID (METAL_PROJECT_ID)")
-	createVirtualNetworkCmd.Flags().StringVarP(&facility, "facility", "f", "", "Code of the facility")
-	createVirtualNetworkCmd.Flags().StringVarP(&metro, "metro", "m", "", "Code of the metro")
-	createVirtualNetworkCmd.Flags().StringVarP(&description, "description", "d", "", "Description of the virtual network")
+	createVirtualNetworkCmd.Flags().StringVarP(&facility, "facility", "f", "", "Code of the facility.")
+	createVirtualNetworkCmd.Flags().StringVarP(&metro, "metro", "m", "", "Code of the metro.")
+	createVirtualNetworkCmd.Flags().StringVarP(&description, "description", "d", "", "A user-friendly description of the virtual network.")
 	createVirtualNetworkCmd.Flags().IntVarP(&vxlan, "vxlan", "", 0, "Optional VXLAN ID. Must be between 2 and 3999 and can only be used with --metro.")
 
 	_ = createVirtualNetworkCmd.MarkFlagRequired("project-id")

--- a/internal/vlan/delete.go
+++ b/internal/vlan/delete.go
@@ -47,9 +47,9 @@ func (c *Client) Delete() *cobra.Command {
 	// deleteVirtualNetworkCmd represents the deleteVirtualNetwork command
 	var deleteVirtualNetworkCmd = &cobra.Command{
 		Use: `delete -i <virtual_network_UUID> [-f] [global_options]`,
-		Short: "Deletes a virtual network",
+		Short: "Deletes a virtual network.",
 		Long: "Deletes the specified VLAN with a confirmation prompt. To skip the confirmation use --force. You are not able to delete a VLAN that is attached to any ports.",
-		Example: heredoc.Doc(` 
+		Example: heredoc.Doc(`
 			# Deletes a VLAN, with confirmation.
 			metal virtual-network delete -i 77e6d57a-d7a4-4816-b451-cf9b043444e2
 			>
@@ -78,9 +78,9 @@ func (c *Client) Delete() *cobra.Command {
 		},
 	}
 
-	deleteVirtualNetworkCmd.Flags().StringVarP(&vnetID, "id", "i", "", "UUID of the vlan")
+	deleteVirtualNetworkCmd.Flags().StringVarP(&vnetID, "id", "i", "", "UUID of the VLAN.")
 	_ = deleteVirtualNetworkCmd.MarkFlagRequired("id")
-	deleteVirtualNetworkCmd.Flags().BoolVarP(&force, "force", "f", false, "Force removal of the virtual network")
+	deleteVirtualNetworkCmd.Flags().BoolVarP(&force, "force", "f", false, "Skips confirmation for the removal of the virtual network.")
 
 	return deleteVirtualNetworkCmd
 }

--- a/internal/vlan/delete.go
+++ b/internal/vlan/delete.go
@@ -26,7 +26,6 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/MakeNowJust/heredoc"
 )
 
 func (c *Client) Delete() *cobra.Command {
@@ -46,18 +45,16 @@ func (c *Client) Delete() *cobra.Command {
 
 	// deleteVirtualNetworkCmd represents the deleteVirtualNetwork command
 	var deleteVirtualNetworkCmd = &cobra.Command{
-		Use: `delete -i <virtual_network_UUID> [-f] [global_options]`,
+		Use: `delete -i <virtual_network_UUID> [-f]`,
 		Short: "Deletes a virtual network.",
 		Long: "Deletes the specified VLAN with a confirmation prompt. To skip the confirmation use --force. You are not able to delete a VLAN that is attached to any ports.",
-		Example: heredoc.Doc(`
-			# Deletes a VLAN, with confirmation.
-			metal virtual-network delete -i 77e6d57a-d7a4-4816-b451-cf9b043444e2
-			>
-			✔ Are you sure you want to delete virtual network 77e6d57a-d7a4-4816-b451-cf9b043444e2: y
+		Example: `  # Deletes a VLAN, with confirmation.
+  metal virtual-network delete -i 77e6d57a-d7a4-4816-b451-cf9b043444e2
+  >
+  ✔ Are you sure you want to delete virtual network 77e6d57a-d7a4-4816-b451-cf9b043444e2: y
 		
-			# Deletes a VLAN, skipping confirmation.
-			metal virtual-network delete -f -i 77e6d57a-d7a4-4816-b451-cf9b043444e2
-		`),
+  # Deletes a VLAN, skipping confirmation.
+  metal virtual-network delete -f -i 77e6d57a-d7a4-4816-b451-cf9b043444e2`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			

--- a/internal/vlan/delete.go
+++ b/internal/vlan/delete.go
@@ -26,6 +26,7 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/MakeNowJust/heredoc"
 )
 
 func (c *Client) Delete() *cobra.Command {
@@ -45,15 +46,23 @@ func (c *Client) Delete() *cobra.Command {
 
 	// deleteVirtualNetworkCmd represents the deleteVirtualNetwork command
 	var deleteVirtualNetworkCmd = &cobra.Command{
-		Use:   "delete",
-		Short: "Deletes a Virtual Network",
-		Long: `Example:
+		Use: `delete -i <virtual_network_UUID> [-f] [global_options]`,
+		Short: "Deletes a virtual network",
+		Long: "Deletes the specified VLAN with a confirmation prompt. To skip the confirmation use --force. You are not able to delete a VLAN that is attached to any ports.",
+		Example: heredoc.Doc(` 
+			# Deletes a VLAN, with confirmation.
+			metal virtual-network delete -i 77e6d57a-d7a4-4816-b451-cf9b043444e2
+			>
+			✔ Are you sure you want to delete virtual network 77e6d57a-d7a4-4816-b451-cf9b043444e2: y
+		
+			# Deletes a VLAN, skipping confirmation.
+			metal virtual-network delete -f -i 77e6d57a-d7a4-4816-b451-cf9b043444e2
+		`),
 
-metal virtual-network delete -i [virtual_network_UUID]
-
-	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			
 			cmd.SilenceUsage = true
+			
 			if !force {
 				prompt := promptui.Prompt{
 					Label:     fmt.Sprintf("Are you sure you want to delete virtual network %s", vnetID),

--- a/internal/vlan/retrieve.go
+++ b/internal/vlan/retrieve.go
@@ -35,7 +35,7 @@ func (c *Client) Retrieve() *cobra.Command {
 		Use: `get -p <project_UUID>`,
 		Aliases: []string{"list"},
 		Short: "Lists virtual networks.",
-		Long: "Retrieves a list of virtual networks for the specified project.",
+		Long: "Retrieves a list of all VLANs for the specified project.",
 		Example:  `
   # Lists virtual networks for project 3b0795ba-ec9a-4a9e-83a7-043e7e11407c:
   virtual-network get -p 3b0795ba-ec9a-4a9e-83a7-043e7e11407c`,

--- a/internal/vlan/retrieve.go
+++ b/internal/vlan/retrieve.go
@@ -35,7 +35,8 @@ func (c *Client) Retrieve() *cobra.Command {
 	var retrieveVirtualNetworksCmd = &cobra.Command{
 		Use: `get -p <project_UUID> [global_options]`,
 		Aliases: []string{"list"},
-		Short:   "Retrieves a list of virtual networks for the specified project.",
+		Short: "Lists virtual networks.",
+		Long: "Retrieves a list of virtual networks for the specified project.",
 		Example: heredoc.Doc(`
 			# Lists virtual networks for project 3b0795ba-ec9a-4a9e-83a7-043e7e11407c:
 			virtual-network get -p 3b0795ba-ec9a-4a9e-83a7-043e7e11407c

--- a/internal/vlan/retrieve.go
+++ b/internal/vlan/retrieve.go
@@ -38,7 +38,7 @@ func (c *Client) Retrieve() *cobra.Command {
 		Long: "Retrieves a list of all VLANs for the specified project.",
 		Example:  `
   # Lists virtual networks for project 3b0795ba-ec9a-4a9e-83a7-043e7e11407c:
-  virtual-network get -p 3b0795ba-ec9a-4a9e-83a7-043e7e11407c`,
+  metal virtual-network get -p 3b0795ba-ec9a-4a9e-83a7-043e7e11407c`,
 		
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true

--- a/internal/vlan/retrieve.go
+++ b/internal/vlan/retrieve.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/MakeNowJust/heredoc"
 )
 
 func (c *Client) Retrieve() *cobra.Command {
@@ -33,14 +32,13 @@ func (c *Client) Retrieve() *cobra.Command {
 
 	// retrieveVirtualNetworksCmd represents the retrieveVirtualNetworks command
 	var retrieveVirtualNetworksCmd = &cobra.Command{
-		Use: `get -p <project_UUID> [global_options]`,
+		Use: `get -p <project_UUID>`,
 		Aliases: []string{"list"},
 		Short: "Lists virtual networks.",
 		Long: "Retrieves a list of virtual networks for the specified project.",
-		Example: heredoc.Doc(`
-			# Lists virtual networks for project 3b0795ba-ec9a-4a9e-83a7-043e7e11407c:
-			virtual-network get -p 3b0795ba-ec9a-4a9e-83a7-043e7e11407c
-		`),
+		Example:  `
+  # Lists virtual networks for project 3b0795ba-ec9a-4a9e-83a7-043e7e11407c:
+  virtual-network get -p 3b0795ba-ec9a-4a9e-83a7-043e7e11407c`,
 		
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
@@ -59,7 +57,7 @@ func (c *Client) Retrieve() *cobra.Command {
 			return c.Out.Output(vnets, header, &data)
 		},
 	}
-	retrieveVirtualNetworksCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID (METAL_PROJECT_ID)")
+	retrieveVirtualNetworksCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "The project's UUID. This flag is required, unless specified in the config created by metal init or set as METAL_PROJECT_ID environment variable.")
 	_ = retrieveVirtualNetworksCmd.MarkFlagRequired("project-id")
 
 	return retrieveVirtualNetworksCmd

--- a/internal/vlan/retrieve.go
+++ b/internal/vlan/retrieve.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/MakeNowJust/heredoc"
 )
 
 func (c *Client) Retrieve() *cobra.Command {
@@ -32,14 +33,14 @@ func (c *Client) Retrieve() *cobra.Command {
 
 	// retrieveVirtualNetworksCmd represents the retrieveVirtualNetworks command
 	var retrieveVirtualNetworksCmd = &cobra.Command{
-		Use:     "get",
+		Use: `get -p <project_UUID> [global_options]`,
 		Aliases: []string{"list"},
-		Short:   "Retrieves a list of virtual networks for a single project.",
-		Long: `Example:
-
-metal virtual-network get -p [project_UUID]
-
-	`,
+		Short:   "Retrieves a list of virtual networks for the specified project.",
+		Example: heredoc.Doc(`
+			# Lists virtual networks for project 3b0795ba-ec9a-4a9e-83a7-043e7e11407c:
+			virtual-network get -p 3b0795ba-ec9a-4a9e-83a7-043e7e11407c
+		`),
+		
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			vnets, _, err := c.Service.List(projectID, c.Servicer.ListOptions(nil, nil))

--- a/internal/vlan/vlan.go
+++ b/internal/vlan/vlan.go
@@ -34,10 +34,10 @@ type Client struct {
 
 func (c *Client) NewCommand() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "virtual-network",
+		Use: `virtual-network`,
 		Aliases: []string{"vlan", "vlans"},
-		Short:   "Virtual network operations",
-		Long:    `Virtual network operations: create, delete and get`,
+		Short: "Virtual network (VLAN) operations",
+		Long: "Virtual network (VLAN) operations : create, get, delete",
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if root := cmd.Root(); root != nil {

--- a/internal/vlan/vlan.go
+++ b/internal/vlan/vlan.go
@@ -36,8 +36,8 @@ func (c *Client) NewCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use: `virtual-network`,
 		Aliases: []string{"vlan", "vlans"},
-		Short: "Virtual network (VLAN) operations",
-		Long: "Virtual network (VLAN) operations : create, get, delete",
+		Short: "Virtual network (VLAN) operations. For more information on how VLANs work in Equinix Metal, visit https://metal.equinix.com/developers/docs/layer2-networking/vlans/.",
+		Long: "Virtual network (VLAN) operations : create, get, delete.",
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if root := cmd.Root(); root != nil {


### PR DESCRIPTION
- standardizes `Use:` field for each command
- adds content for both `Short:` and `Long:` fields in each command
- adds `Example:` commands where appropriate
- fixes typo in the global flags
- updates some of the flag descriptions to be a bit more explicit. Especially for --project-id.