### PR TITLE
removes build ignore for windows/darwin arm

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,15 +27,7 @@ builds:
   goarm:
     - 6
     - 7
-  ignore:
-    - goos: windows
-      goarch: arm
-    - goos: windows
-      goarch: arm64
-    - goos: darwin
-      goarch: arm64
-    - goos: darwin
-      goarch: arm
+
 archives:
 - format: binary
   name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"


### PR DESCRIPTION
Removes the ignore lines from goreleaser so builds will continue for windows and darwin arm instances and publish artifacts.