### PR TITLE
docs: Use capital P `-P` flag for plan

### DIFF
--- a/docs/metal_device_create.md
+++ b/docs/metal_device_create.md
@@ -14,10 +14,10 @@ metal device create -p <project_id> (-m <metro> | -f <facility>) -P <plan> -H <h
 
 ```
   # Provisions a c3.small.x86 in the Dallas metro running Ubuntu 20.04:
-  metal device create -p $METAL_PROJECT_ID -p c3.small.x86 -m da -H test-staging-2 -O ubuntu_20_04,
+  metal device create -p $METAL_PROJECT_ID -P c3.small.x86 -m da -H test-staging-2 -O ubuntu_20_04
 
   # Provisions a c3.medium.x86 in Silicon Valley, running Rocky Linux, from a hardware reservation:
-  metal device create -p $METAL_PROJECT_ID -p c3.medium.x86 -m sv -H test-rocky -O rocky_8 -r 47161704-1715-4b45-8549-fb3f4b2c32c7
+  metal device create -p $METAL_PROJECT_ID -P c3.medium.x86 -m sv -H test-rocky -O rocky_8 -r 47161704-1715-4b45-8549-fb3f4b2c32c7
 ```
 
 ### Options


### PR DESCRIPTION
The docs use small P to specify plan, so this conflicts with the project
id. This commit fixes the plan type flag to use capital P.

Signed-off-by: Suraj Deshmukh <suraj@kinvolk.io>