### PR TITLE
port-id is required for port commands

### DIFF
--- a/internal/ports/convert.go
+++ b/internal/ports/convert.go
@@ -37,7 +37,7 @@ func (c *Client) Convert() *cobra.Command {
 	// retrievePortCmd represents the retrievePort command
 	retrievePortCmd := &cobra.Command{
 		Use:     `convert -i <port_UUID> [--bonded] [--bulk] --layer2 [--force] [--public-ipv4] [--public-ipv6]`,
-		Aliases: []string{"list"},
+		Aliases: []string{},
 		Short:   "Converts a list of ports or the details of the specified port.",
 		Long:    "Converts a list of ports or the details of the specified port. Details of an port are only available to its members.",
 		Example: `  # Converts list of the current user's ports:

--- a/internal/ports/retrieve.go
+++ b/internal/ports/retrieve.go
@@ -33,7 +33,7 @@ func (c *Client) Retrieve() *cobra.Command {
 	// retrievePortCmd represents the retrievePort command
 	retrievePortCmd := &cobra.Command{
 		Use:     `get -i <port_UUID>`,
-		Aliases: []string{"list"},
+		Aliases: []string{},
 		Short:   "Retrieves the details of the specified port.",
 		Long:    "Retrieves the details of the specified port. Details of an port are only available to its members.",
 		Example: `  # Retrieves list of the current user's ports:
@@ -62,5 +62,7 @@ func (c *Client) Retrieve() *cobra.Command {
 	}
 
 	retrievePortCmd.Flags().StringVarP(&portID, "port-id", "i", "", "The UUID of a port.")
+	_ = retrievePortCmd.MarkFlagRequired("port-id")
+
 	return retrievePortCmd
 }

--- a/internal/ports/vlans.go
+++ b/internal/ports/vlans.go
@@ -93,5 +93,7 @@ func (c *Client) Vlans() *cobra.Command {
 	retrievePortCmd.Flags().StringSliceVarP(&assignments, "assign", "a", []string{}, "A VXLAN to assign to the port. May also be used to change a Native VLAN assignment to tagged (non-native).")
 	retrievePortCmd.Flags().StringSliceVarP(&unassignments, "unassign", "u", []string{}, "A VXLAN to unassign from a port.")
 
+	_ = retrievePortCmd.MarkFlagRequired("port-id")
+
 	return retrievePortCmd
 }


### PR DESCRIPTION
Fixes the requirement for port-id parameters in port commands.
Removes "list" alias from port commands, which can not be listed.