### PR TITLE
fix "ip available" --cidr filtering using packngo v0.28.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,10 @@ go 1.19
 require (
 	github.com/manifoldco/promptui v0.9.0
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/packethost/packngo v0.28.0
+	github.com/packethost/packngo v0.28.1
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.13.0
-	golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be
 	golang.org/x/term v0.0.0-20220919170432-7a66f970e087
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -30,6 +29,7 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
+	golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/packethost/packngo v0.28.0 h1:3KSmYGgVzVxgH/oYCA+45L1OnPIKU/kWu6uEduB/7qY=
-github.com/packethost/packngo v0.28.0/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
+github.com/packethost/packngo v0.28.1 h1:2Bo64Ku3F869oUmE2IrnURanN0XAmZmhI8wTem2sq64=
+github.com/packethost/packngo v0.28.1/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.5 h1:ipoSadvV8oGUjnUbMub59IDPPwfxF694nG/jwbMiyQg=


### PR DESCRIPTION
### Before 
```
$ metal ip available -r <some-30-cidr-reservation>  --cidr 31
Error: Could not get available IP addresses: GET https://api.equinix.com/metal/v1/ips/<some-30-cidr-reservation>/available: 422 Missing cidr parameter
```

### After 
```
$ go run ./cmd/metal ip available -r <some-30-cidr-reservation>  --cidr 31
+-------------------+
|   AVAILABLE IPS   |
+-------------------+
| <IP>/31 |
| <IP>/31 |
+-------------------+
```