### PR TITLE
reinstall: pass operatingSystem and split PreserveData and DeprovisionFast

### DIFF
--- a/docs/metal_device_reinstall.md
+++ b/docs/metal_device_reinstall.md
@@ -13,6 +13,7 @@ metal device reinstall -d <device-id> [flags]
 ### Options
 
 ```
+      --deprovision-fast          Avoid optional potentially slow clean up tasks
   -h, --help                      help for reinstall
   -d, --id string                 ID of device to be reinstalled
   -O, --operating-system string   Operating system name for the device

--- a/internal/devices/reinstall.go
+++ b/internal/devices/reinstall.go
@@ -32,6 +32,7 @@ func (c *Client) Reinstall() *cobra.Command {
 		id string
 
 		operatingSystem string
+		deprovisionFast bool
 		preserveData    bool
 	)
 
@@ -44,7 +45,7 @@ func (c *Client) Reinstall() *cobra.Command {
 			request := packngo.DeviceReinstallFields{
 				OperatingSystem: operatingSystem,
 				PreserveData:    preserveData,
-				DeprovisionFast: preserveData,
+				DeprovisionFast: deprovisionFast,
 			}
 
 			_, err := c.Service.Reinstall(id, &request)
@@ -59,6 +60,7 @@ func (c *Client) Reinstall() *cobra.Command {
 	_ = reinstallDeviceCmd.MarkFlagRequired("id")
 
 	reinstallDeviceCmd.Flags().StringVarP(&operatingSystem, "operating-system", "O", "", "Operating system name for the device")
+	reinstallDeviceCmd.Flags().BoolVarP(&deprovisionFast, "deprovision-fast", "", false, "Avoid optional potentially slow clean up tasks")
 	reinstallDeviceCmd.Flags().BoolVarP(&preserveData, "preserve-data", "", false, "Avoid wiping data on disks where the os is *not* to be installed into")
 
 	return reinstallDeviceCmd

--- a/internal/devices/reinstall.go
+++ b/internal/devices/reinstall.go
@@ -42,7 +42,7 @@ func (c *Client) Reinstall() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			request := packngo.DeviceReinstallFields{
-				OperatingSystem: "",
+				OperatingSystem: operatingSystem,
 				PreserveData:    preserveData,
 				DeprovisionFast: preserveData,
 			}


### PR DESCRIPTION
I forgot to pass `operatingSystem` in to the packngo call.

I've changed the code so `PreseveData` and `FastDeprovision` aren't tied together. In the backend deprovision process `PreserveData` currently implies `DeprovisionFast`. `DeprovisionFast` is currently only useful to avoid the slow wipe of disks that will be used to reinstall the os into. In the future `DeprovisionFast` could also skip lengthy inventory collection steps that don't really need to happen for a reinstall.