### PR TITLE
correct hardware-reservation get/move examples to use -

### DIFF
--- a/docs/metal_hardware-reservation_get.md
+++ b/docs/metal_hardware-reservation_get.md
@@ -14,10 +14,10 @@ metal hardware-reservation get [-p <project_id>] | [-i <hardware_reservation_id>
 
 ```
   # Retrieve all hardware reservations of a project:
-  metal hardware_reservations get -p $METAL_PROJECT_ID
+  metal hardware-reservations get -p $METAL_PROJECT_ID
   
   # Retrieve the details of a specific hardware reservation:
-  metal hardware_reservations get -i 8404b73c-d18f-4190-8c49-20bb17501f88
+  metal hardware-reservations get -i 8404b73c-d18f-4190-8c49-20bb17501f88
 ```
 
 ### Options

--- a/docs/metal_hardware-reservation_move.md
+++ b/docs/metal_hardware-reservation_move.md
@@ -14,7 +14,7 @@ metal hardware-reservation move -i <hardware_reservation_id> -p <project_id> [fl
 
 ```
   # Moves a hardware reservation to the specified Project:
-  metal hardware_reservation move -i 8404b73c-d18f-4190-8c49-20bb17501f88 -p 278bca90-f6b2-4659-b1a4-1bdffa0d80b7
+  metal hardware-reservation move -i 8404b73c-d18f-4190-8c49-20bb17501f88 -p 278bca90-f6b2-4659-b1a4-1bdffa0d80b7
 ```
 
 ### Options

--- a/internal/hardware/move.go
+++ b/internal/hardware/move.go
@@ -34,7 +34,7 @@ func (c *Client) Move() *cobra.Command {
 		Short: "Moves a hardware reservation.",
 		Long:  "Moves a hardware reservation to a specified project. Both the hardware reservation ID and the Project ID for the destination project are required.",
 		Example: `  # Moves a hardware reservation to the specified Project:
-  metal hardware_reservation move -i 8404b73c-d18f-4190-8c49-20bb17501f88 -p 278bca90-f6b2-4659-b1a4-1bdffa0d80b7`,
+  metal hardware-reservation move -i 8404b73c-d18f-4190-8c49-20bb17501f88 -p 278bca90-f6b2-4659-b1a4-1bdffa0d80b7`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true

--- a/internal/hardware/retrieve.go
+++ b/internal/hardware/retrieve.go
@@ -35,10 +35,10 @@ func (c *Client) Retrieve() *cobra.Command {
 		Short:   "Lists a Project's hardware reservations or the details of a specified hardware reservation.",
 		Long:    "Lists a Project's hardware reservations or the details of a specified hardware reservation. When using --json or --yaml flags, the --include=project,facility,device flag is implied.",
 		Example: `  # Retrieve all hardware reservations of a project:
-  metal hardware_reservations get -p $METAL_PROJECT_ID
+  metal hardware-reservations get -p $METAL_PROJECT_ID
   
   # Retrieve the details of a specific hardware reservation:
-  metal hardware_reservations get -i 8404b73c-d18f-4190-8c49-20bb17501f88`,
+  metal hardware-reservations get -i 8404b73c-d18f-4190-8c49-20bb17501f88`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			projectID, _ := cmd.Flags().GetString("project-id")


### PR DESCRIPTION
This is a small update to correct a few `hardware-reservation` `get` and `move` examples to swap a `-` instead of `_`.

Thanks for this tool, it's been very useful 🙏🏼 