### PR TITLE
Add Organization ID to metal env

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,5 +13,8 @@ Available via [https://github.com/equinix/metal-cli/blob/master/.github/CODE_OF_
 ### How to Submit Change Requests
 Please submit change requests and / or features via [Issues](https://github.com/equinix/metal-cli/issues). There's no guarantee it'll be changed, but you never know until you try. We'll try to add comments as soon as possible, though.
 
+#### Pull Requests
+All command changes must be reflected in the documentation, this includes new commands and changes to options. The documentation is generated via `make generate-docs`.
+
 ### How to Report a Bug
 Bugs are problems in code, in the functionality of an application or in its UI design; you can submit them through [Issues](https://github.com/equinix/metal-cli/issues) as well.

--- a/docs/metal_env.md
+++ b/docs/metal_env.md
@@ -4,7 +4,7 @@ Prints or generates environment variables.
 
 ### Synopsis
 
-Prints or generates environment variables. Currently emitted variables: METAL_AUTH_TOKEN, METAL_PROJECT_ID, METAL_CONFIG. Use the --project-id flag to set the METAL_PROJECT_ID variable.
+Prints or generates environment variables. Currently emitted variables: METAL_AUTH_TOKEN, METAL_ORGANIZATION_ID, METAL_PROJECT_ID, METAL_CONFIG. Use the --project-id flag to set the METAL_PROJECT_ID variable. Use the --organization-id flag to set the METAL_ORGANIZATION_ID variable.
 
 ```
 metal env [-p <project_id>]
@@ -29,8 +29,9 @@ metal env [-p <project_id>]
 ### Options
 
 ```
-  -h, --help                help for env
-  -p, --project-id string   A project UUID to set as an environment variable.
+  -h, --help                     help for env
+  -O, --organization-id string   A organization UUID to set as an environment variable.
+  -p, --project-id string        A project UUID to set as an environment variable.
 ```
 
 ### Options inherited from parent commands

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -51,7 +51,7 @@ func (c *Client) NewCommand() *cobra.Command {
 	envCmd := &cobra.Command{
 		Use:   `env [-p <project_id>]`,
 		Short: "Prints or generates environment variables.",
-		Long:  "Prints or generates environment variables. Currently emitted variables: METAL_AUTH_TOKEN, METAL_PROJECT_ID, METAL_CONFIG. Use the --project-id flag to set the METAL_PROJECT_ID variable.",
+		Long:  "Prints or generates environment variables. Currently emitted variables: METAL_AUTH_TOKEN, METAL_ORGANIZATION_ID, METAL_PROJECT_ID, METAL_CONFIG. Use the --project-id flag to set the METAL_PROJECT_ID variable. Use the --organization-id flag to set the METAL_ORGANIZATION_ID variable.",
 		Example: `  # Print the current environment variables:
   metal env
   
@@ -66,10 +66,12 @@ func (c *Client) NewCommand() *cobra.Command {
 
 		DisableFlagsInUseLine: true,
 		Run: func(cmd *cobra.Command, args []string) {
+			organizationID, _ := cmd.Flags().GetString("organization-id")
 			projectID, _ := cmd.Flags().GetString("project-id")
 			config, _ := cmd.Flags().GetString("config")
 
 			fmt.Printf("%s=%s\n", c.apiTokenEnvVar, c.tokener.Token())
+			fmt.Printf("METAL_ORGANIZATION_ID=%s\n", organizationID)
 			fmt.Printf("METAL_PROJECT_ID=%s\n", projectID)
 			fmt.Printf("METAL_CONFIG=%s\n", config)
 		},
@@ -77,6 +79,8 @@ func (c *Client) NewCommand() *cobra.Command {
 
 	// 	envCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID (METAL_PROJECT_ID)")
 	envCmd.Flags().StringP("project-id", "p", "", "A project UUID to set as an environment variable.")
+
+	envCmd.Flags().StringP("organization-id", "O", "", "A organization UUID to set as an environment variable.")
 
 	return envCmd
 }


### PR DESCRIPTION
Added "organization-id" variable and "O" shorthand to address "Organization ID should be returned in metal env

Fixes #245

Closes #248 
Cioses #247 