### PR TITLE
Add env output formats for capp and terraform

### DIFF
--- a/docs/metal.md
+++ b/docs/metal.md
@@ -14,7 +14,7 @@ Command line interface for Equinix Metal
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
   -h, --help                 help for metal
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_2fa.md
+++ b/docs/metal_2fa.md
@@ -19,7 +19,7 @@ Enable or disable two-factor authentication on your user account or receive an O
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_2fa_disable.md
+++ b/docs/metal_2fa_disable.md
@@ -36,7 +36,7 @@ metal 2fa disable (-a | -s) --code <OTP_code>  [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_2fa_enable.md
+++ b/docs/metal_2fa_enable.md
@@ -36,7 +36,7 @@ metal 2fa enable (-s | -a) --code <OTP_code> [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_2fa_receive.md
+++ b/docs/metal_2fa_receive.md
@@ -35,7 +35,7 @@ metal 2fa receive (-s | -a) [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_capacity.md
+++ b/docs/metal_capacity.md
@@ -19,7 +19,7 @@ Capacity operations. For more information on capacity in metros, visit https://m
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_capacity_check.md
+++ b/docs/metal_capacity_check.md
@@ -37,7 +37,7 @@ metal capacity check (-m <metro> | -f <facility>) -P <plan> -q <quantity> [flags
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_capacity_get.md
+++ b/docs/metal_capacity_get.md
@@ -41,7 +41,7 @@ metal capacity get [-m | -f] | [--metros <list> | --facilities <list>] [-P <list
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_completion.md
+++ b/docs/metal_completion.md
@@ -51,7 +51,7 @@ metal completion [bash | zsh | fish | powershell]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_device.md
+++ b/docs/metal_device.md
@@ -19,7 +19,7 @@ Device operations that control server provisioning, metadata, and basic operatio
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_device_create.md
+++ b/docs/metal_device_create.md
@@ -51,7 +51,7 @@ metal device create -p <project_id> (-m <metro> | -f <facility>) -P <plan> -H <h
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_device_delete.md
+++ b/docs/metal_device_delete.md
@@ -37,7 +37,7 @@ metal device delete -i <device_id> [-f] [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_device_get.md
+++ b/docs/metal_device_get.md
@@ -35,7 +35,7 @@ metal device get [-p <project_id>] | [-i <device_id>] [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_device_reboot.md
+++ b/docs/metal_device_reboot.md
@@ -31,7 +31,7 @@ metal device reboot -i <device_id> [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_device_reinstall.md
+++ b/docs/metal_device_reinstall.md
@@ -37,7 +37,7 @@ metal device reinstall --id <device-id> [--operating-system <os_slug>] [--deprov
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_device_start.md
+++ b/docs/metal_device_start.md
@@ -31,7 +31,7 @@ metal device start -i <device_id> [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_device_stop.md
+++ b/docs/metal_device_stop.md
@@ -31,7 +31,7 @@ metal device stop -i <device_id> [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_device_update.md
+++ b/docs/metal_device_update.md
@@ -39,7 +39,7 @@ metal device update -i <device_id> [-H <hostname>] [-d <description>] [--locked 
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_docs.md
+++ b/docs/metal_docs.md
@@ -30,7 +30,7 @@ metal docs <destination>
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_emdocs.md
+++ b/docs/metal_emdocs.md
@@ -30,7 +30,7 @@ metal emdocs <destination>
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_env.md
+++ b/docs/metal_env.md
@@ -16,7 +16,10 @@ metal env [-p <project_id>]
   # Print the current environment variables:
   metal env
   
-  # Load environment variables in Bash, Zsh:
+  # Print the current environment variables in Terraform format:
+  metal env --output terraform
+  
+    # Load environment variables in Bash, Zsh:
   source <(metal env)
   
   # Load environment variables in Bash 3.2.x:
@@ -29,6 +32,7 @@ metal env [-p <project_id>]
 ### Options
 
 ```
+      --export                   Export the environment variables.
   -h, --help                     help for env
   -O, --organization-id string   A organization UUID to set as an environment variable.
   -p, --project-id string        A project UUID to set as an environment variable.
@@ -41,7 +45,7 @@ metal env [-p <project_id>]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_event.md
+++ b/docs/metal_event.md
@@ -19,7 +19,7 @@ Events information for organizations, projects, devices, and the current user.
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_event_get.md
+++ b/docs/metal_event_get.md
@@ -46,7 +46,7 @@ metal event get [-p <project_id>] | [-d <device_id>] | [-i <event_id>] | [-O <or
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_facilities.md
+++ b/docs/metal_facilities.md
@@ -19,7 +19,7 @@ Information about specific facilities. Facility-level operations have mostly bee
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_facilities_get.md
+++ b/docs/metal_facilities_get.md
@@ -30,7 +30,7 @@ metal facilities get [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_gateway.md
+++ b/docs/metal_gateway.md
@@ -19,7 +19,7 @@ A Metal Gateway provides a single IPv4 address as a gateway for a subnet. For mo
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_gateway_create.md
+++ b/docs/metal_gateway_create.md
@@ -37,7 +37,7 @@ metal gateway create -p <project_UUID> --virtual-network <virtual_network_UUID> 
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_gateway_delete.md
+++ b/docs/metal_gateway_delete.md
@@ -37,7 +37,7 @@ metal gateway delete -i <metal_gateway_UUID> [-f] [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_gateway_get.md
+++ b/docs/metal_gateway_get.md
@@ -32,7 +32,7 @@ metal gateway get -p <project_UUID> [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_hardware-reservation.md
+++ b/docs/metal_hardware-reservation.md
@@ -19,7 +19,7 @@ Information and operations on Hardware Reservations. Provisioning specific devic
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_hardware-reservation_get.md
+++ b/docs/metal_hardware-reservation_get.md
@@ -35,7 +35,7 @@ metal hardware-reservation get [-p <project_id>] | [-i <hardware_reservation_id>
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_hardware-reservation_move.md
+++ b/docs/metal_hardware-reservation_move.md
@@ -32,7 +32,7 @@ metal hardware-reservation move -i <hardware_reservation_id> -p <project_id> [fl
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_init.md
+++ b/docs/metal_init.md
@@ -33,7 +33,7 @@ metal init
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ip.md
+++ b/docs/metal_ip.md
@@ -19,7 +19,7 @@ IP address and subnet operations, including requesting IPv4 and IPv6 addresses, 
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ip_assign.md
+++ b/docs/metal_ip_assign.md
@@ -32,7 +32,7 @@ metal ip assign -a <IP_address> -d <device_UUID> [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ip_available.md
+++ b/docs/metal_ip_available.md
@@ -32,7 +32,7 @@ metal ip available -r <reservation_UUID> -c <size_of_subnet> [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ip_get.md
+++ b/docs/metal_ip_get.md
@@ -39,7 +39,7 @@ metal ip get -p <project_UUID> | -a <assignment_UUID> | -r <reservation_UUID> [f
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ip_remove.md
+++ b/docs/metal_ip_remove.md
@@ -31,7 +31,7 @@ metal ip remove -i <reservation_UUID> [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ip_request.md
+++ b/docs/metal_ip_request.md
@@ -37,7 +37,7 @@ metal ip request -p <project_id> -t <ip_address_type> -q <quantity> (-m <metro> 
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ip_unassign.md
+++ b/docs/metal_ip_unassign.md
@@ -31,7 +31,7 @@ metal ip unassign -i <assignment_UUID>  [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_metros.md
+++ b/docs/metal_metros.md
@@ -19,7 +19,7 @@ Get information on Metro locations. For more information on https://metal.equini
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_metros_get.md
+++ b/docs/metal_metros_get.md
@@ -30,7 +30,7 @@ metal metros get [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_operating-systems.md
+++ b/docs/metal_operating-systems.md
@@ -19,7 +19,7 @@ Information on available operating systems. For more information on which operat
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_operating-systems_get.md
+++ b/docs/metal_operating-systems_get.md
@@ -30,7 +30,7 @@ metal operating-systems get [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_organization.md
+++ b/docs/metal_organization.md
@@ -19,7 +19,7 @@ Information and management of Organization-level settings. Documentation on orga
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_organization_create.md
+++ b/docs/metal_organization_create.md
@@ -38,7 +38,7 @@ metal organization create -n <name> [-d <description>] [-w <website_URL>] [-t <t
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_organization_delete.md
+++ b/docs/metal_organization_delete.md
@@ -37,7 +37,7 @@ metal organization delete -i <organization_UUID> [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_organization_get.md
+++ b/docs/metal_organization_get.md
@@ -34,7 +34,7 @@ metal organization get -i <organization_UUID> [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_organization_payment-methods.md
+++ b/docs/metal_organization_payment-methods.md
@@ -31,7 +31,7 @@ metal organization payment-methods -i <organization_UUID> [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_organization_update.md
+++ b/docs/metal_organization_update.md
@@ -36,7 +36,7 @@ metal organization update -i <organization_UUID> [-n <name>] [-d <description>] 
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_plan.md
+++ b/docs/metal_plan.md
@@ -19,7 +19,7 @@ Information on server plans. For more information on the different Equinix Metal
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_plan_get.md
+++ b/docs/metal_plan_get.md
@@ -30,7 +30,7 @@ metal plan get [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_port.md
+++ b/docs/metal_port.md
@@ -19,7 +19,7 @@ Information and operations for converting ports between networking modes and man
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_port_convert.md
+++ b/docs/metal_port_convert.md
@@ -46,7 +46,7 @@ metal port convert -i <port_UUID> [--bonded] [--bulk] --layer2 [--force] [--publ
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_port_get.md
+++ b/docs/metal_port_get.md
@@ -31,7 +31,7 @@ metal port get -i <port_UUID> [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_port_vlan.md
+++ b/docs/metal_port_vlan.md
@@ -40,7 +40,7 @@ metal port vlan -i <port_UUID> [--native <vlan>] [--unassign <vlan>]... [--assig
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_project.md
+++ b/docs/metal_project.md
@@ -19,7 +19,7 @@ Information and management for Projects and Project-level BGP. Documentation on 
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_project_bgp-config.md
+++ b/docs/metal_project_bgp-config.md
@@ -31,7 +31,7 @@ metal project bgp-config --project-id <project_UUID> [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_project_bgp-enable.md
+++ b/docs/metal_project_bgp-enable.md
@@ -35,7 +35,7 @@ metal project bgp-enable --project-id <project_UUID> --deployment-type <deployme
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_project_bgp-sessions.md
+++ b/docs/metal_project_bgp-sessions.md
@@ -31,7 +31,7 @@ metal project bgp-sessions --project-id <project_UUID> [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_project_create.md
+++ b/docs/metal_project_create.md
@@ -36,7 +36,7 @@ metal project create -n <project_name> [-O <organization_UUID>] [-m <payment_met
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_project_delete.md
+++ b/docs/metal_project_delete.md
@@ -37,7 +37,7 @@ metal project delete --id <project_UUID> [--force] [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_project_get.md
+++ b/docs/metal_project_get.md
@@ -38,7 +38,7 @@ metal project get [-i <project_UUID> | -n <project_name>] [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_project_update.md
+++ b/docs/metal_project_update.md
@@ -36,7 +36,7 @@ metal project update -i <project_UUID> [-n <name>] [-m <payment_method_UUID>] [f
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ssh-key.md
+++ b/docs/metal_ssh-key.md
@@ -19,7 +19,7 @@ SSH key operations for managing SSH keys on user accounts and projects. Keys add
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ssh-key_create.md
+++ b/docs/metal_ssh-key_create.md
@@ -32,7 +32,7 @@ metal ssh-key create --key <public_key> --label <label> [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ssh-key_delete.md
+++ b/docs/metal_ssh-key_delete.md
@@ -37,7 +37,7 @@ metal ssh-key delete --id <SSH-key_UUID> [--force] [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ssh-key_get.md
+++ b/docs/metal_ssh-key_get.md
@@ -39,7 +39,7 @@ metal ssh-key get [-i <SSH-key_UUID>] [-P] [-p <project_id>] [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_ssh-key_update.md
+++ b/docs/metal_ssh-key_update.md
@@ -36,7 +36,7 @@ metal ssh-key update -i <SSH-key_UUID> [-k <public_key>] [-l <label>] [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_user.md
+++ b/docs/metal_user.md
@@ -19,7 +19,7 @@ Adding users or getting their details. For more information on user and account 
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_user_add.md
+++ b/docs/metal_user_add.md
@@ -35,7 +35,7 @@ metal user add --email <email> --roles <roles> [--organization-id <organization_
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_user_get.md
+++ b/docs/metal_user_get.md
@@ -34,7 +34,7 @@ metal user get [-i <user_UUID>] [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_virtual-network.md
+++ b/docs/metal_virtual-network.md
@@ -19,7 +19,7 @@ Managing Virtual Networks on a Project. VLAN assignments to a server's ports is 
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_virtual-network_create.md
+++ b/docs/metal_virtual-network_create.md
@@ -38,7 +38,7 @@ metal virtual-network create -p <project_UUID>  [-m <metro_code> -vxlan <vlan> |
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_virtual-network_delete.md
+++ b/docs/metal_virtual-network_delete.md
@@ -37,7 +37,7 @@ metal virtual-network delete -i <virtual_network_UUID> [-f] [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/docs/metal_virtual-network_get.md
+++ b/docs/metal_virtual-network_get.md
@@ -31,7 +31,7 @@ metal virtual-network get -p <project_UUID> [flags]
       --exclude strings      Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray   Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --include strings      Comma separated Href references to expand in results, may be dotted three levels deep
-  -o, --output string        Output format (*table, json, yaml)
+  -o, --output string        Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).
       --search string        Search keyword for use in 'get' actions. Search is not supported by all resources.
       --sort-by string       Sort fields for use in 'get' actions. Sort is not supported by all resources.
       --sort-dir string      Sort field direction for use in 'get' actions. Sort is not supported by all resources.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -191,8 +191,7 @@ func (c *Client) NewCommand() *cobra.Command {
 	authtoken := rootCmd.PersistentFlags().Lookup("auth-token")
 	authtoken.Hidden = true
 	rootCmd.PersistentFlags().StringVar(&c.cfgFile, "config", c.cfgFile, "Path to JSON or YAML configuration file")
-
-	rootCmd.PersistentFlags().StringVarP(&c.outputFormat, "output", "o", "", "Output format (*table, json, yaml)")
+	rootCmd.PersistentFlags().StringVarP(&c.outputFormat, "output", "o", "", "Output format (*table, json, yaml). env output formats are (*sh, terraform, capp).")
 	c.includes = rootCmd.PersistentFlags().StringSlice("include", nil, "Comma separated Href references to expand in results, may be dotted three levels deep")
 	c.excludes = rootCmd.PersistentFlags().StringSlice("exclude", nil, "Comma separated Href references to collapse in results, may be dotted three levels deep")
 	c.filters = rootCmd.PersistentFlags().StringArray("filter", nil, "Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.")

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -100,6 +100,8 @@ func (c *Client) NewCommand() *cobra.Command {
 		},
 	}
 
+	envCmd.PersistentFlags().StringP("output", "o", "sh", "Output format for environment variables (*sh, terraform, capp).")
+
 	envCmd.Flags().StringP("project-id", "p", "", "A project UUID to set as an environment variable.")
 
 	envCmd.Flags().StringP("organization-id", "O", "", "A organization UUID to set as an environment variable.")

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -55,7 +55,10 @@ func (c *Client) NewCommand() *cobra.Command {
 		Example: `  # Print the current environment variables:
   metal env
   
-  # Load environment variables in Bash, Zsh:
+  # Print the current environment variables in Terraform format:
+  metal env --output terraform
+  
+    # Load environment variables in Bash, Zsh:
   source <(metal env)
   
   # Load environment variables in Bash 3.2.x:
@@ -65,22 +68,71 @@ func (c *Client) NewCommand() *cobra.Command {
   metal env | source`,
 
 		DisableFlagsInUseLine: true,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var formatter func(token, orgID, projID, conPath string) map[string]string
+
 			organizationID, _ := cmd.Flags().GetString("organization-id")
 			projectID, _ := cmd.Flags().GetString("project-id")
 			config, _ := cmd.Flags().GetString("config")
+			output, _ := cmd.Flags().GetString("output")
+			export, _ := cmd.Flags().GetBool("export")
+			prefix := ""
 
-			fmt.Printf("%s=%s\n", c.apiTokenEnvVar, c.tokener.Token())
-			fmt.Printf("METAL_ORGANIZATION_ID=%s\n", organizationID)
-			fmt.Printf("METAL_PROJECT_ID=%s\n", projectID)
-			fmt.Printf("METAL_CONFIG=%s\n", config)
+			switch output {
+			case "sh":
+				formatter = shellEnvWithClientToken(c)
+			case "terraform":
+				formatter = terraformEnv
+			case "capp":
+				formatter = cappEnv
+			default:
+				return fmt.Errorf("Unknown env output format %q", output)
+			}
+
+			if export {
+				prefix = "export "
+			}
+
+			for k, v := range formatter(c.tokener.Token(), organizationID, projectID, config) {
+				fmt.Printf("%s%s=%s\n", prefix, k, v)
+			}
+			return nil
 		},
 	}
 
-	// 	envCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID (METAL_PROJECT_ID)")
 	envCmd.Flags().StringP("project-id", "p", "", "A project UUID to set as an environment variable.")
 
 	envCmd.Flags().StringP("organization-id", "O", "", "A organization UUID to set as an environment variable.")
 
+	envCmd.Flags().Bool("export", false, "Export the environment variables.")
+
 	return envCmd
+}
+
+func terraformEnv(token, orgID, projID, conPath string) map[string]string {
+	return map[string]string{
+		"TF_VAR_metal_auth_token":      token,
+		"TF_VAR_metal_organization_id": orgID,
+		"TF_VAR_metal_project_id":      projID,
+		"TF_VAR_metal_config":          conPath,
+	}
+}
+
+func cappEnv(token, orgID, projID, conPath string) map[string]string {
+	return map[string]string{
+		"PACKET_API_KEY":  token,
+		"ORGANIZATION_ID": orgID,
+		"PROJECT_ID":      projID,
+	}
+}
+
+func shellEnvWithClientToken(c *Client) func(token, orgID, projID, conPath string) map[string]string {
+	return func(token, orgID, projID, conPath string) map[string]string {
+		return map[string]string{
+			c.apiTokenEnvVar:        token,
+			"METAL_ORGANIZATION_ID": orgID,
+			"METAL_PROJECT_ID":      projID,
+			"METAL_CONFIG":          conPath,
+		}
+	}
 }


### PR DESCRIPTION
Add `metal env -o terraform` and `-o capp` support for use in common integration settings.

Also adds `--export` to include `export ` prefixes to output .