### PR TITLE
Updated metal-go client for projects sub-commands

### DIFF
--- a/internal/pagination/pager.go
+++ b/internal/pagination/pager.go
@@ -1,0 +1,26 @@
+package pager
+
+import (
+	"context"
+
+	metal "github.com/equinix-labs/metal-go/metal/v1"
+)
+
+func GetAllProjects(s metal.ProjectsApiService, include []string, exclude []string) ([]metal.Project, error) {
+	var projects []metal.Project
+
+	page := int32(1)     // int32 | Page to return (optional) (default to 1)
+	perPage := int32(20) // int32 | Items returned per page (optional) (default to 10)
+	for {
+		projectPage, _, err := s.FindProjects(context.Background()).Include(include).Exclude(exclude).Page(page).PerPage(perPage).Execute()
+		if err != nil {
+			return nil, err
+		}
+		projects = append(projects, projectPage.GetProjects()...)
+		if projectPage.Meta.GetLastPage() > projectPage.Meta.GetCurrentPage() {
+			page = page + 1
+			continue
+		}
+		return projects, nil
+	}
+}

--- a/internal/projects/create.go
+++ b/internal/projects/create.go
@@ -21,9 +21,10 @@
 package projects
 
 import (
+	"context"
 	"fmt"
 
-	"github.com/packethost/packngo"
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -47,26 +48,24 @@ func (c *Client) Create() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			req := packngo.ProjectCreateRequest{
-				Name: name,
-			}
+			req := metal.NewProjectCreateFromRootInput(name)
 
 			if organizationID != "" {
-				req.OrganizationID = organizationID
+				req.OrganizationId = &organizationID
 			}
 
 			if paymentMethodID != "" {
-				req.PaymentMethodID = paymentMethodID
+				req.PaymentMethodId = &paymentMethodID
 			}
 
-			p, _, err := c.ProjectService.Create(&req)
+			p, _, err := c.ProjectService.CreateProject(context.Background()).ProjectCreateFromRootInput(*req).Execute()
 			if err != nil {
 				return fmt.Errorf("Could not create Project: %w", err)
 			}
 
 			data := make([][]string, 1)
 
-			data[0] = []string{p.ID, p.Name, p.Created}
+			data[0] = []string{p.GetId(), p.GetName(), p.GetCreatedAt().String()}
 			header := []string{"ID", "Name", "Created"}
 			return c.Out.Output(p, header, &data)
 		},

--- a/internal/projects/delete.go
+++ b/internal/projects/delete.go
@@ -21,6 +21,7 @@
 package projects
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/manifoldco/promptui"
@@ -33,7 +34,7 @@ func (c *Client) Delete() *cobra.Command {
 		projectID string
 	)
 	deleteProject := func(id string) error {
-		_, err := c.ProjectService.Delete(id)
+		_, err := c.ProjectService.DeleteProject(context.Background(), id).Execute()
 		if err != nil {
 			return err
 		}

--- a/internal/projects/project.go
+++ b/internal/projects/project.go
@@ -21,6 +21,7 @@
 package projects
 
 import (
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/equinix/metal-cli/internal/outputs"
 	"github.com/packethost/packngo"
 	"github.com/spf13/cobra"
@@ -28,7 +29,7 @@ import (
 
 type Client struct {
 	Servicer         Servicer
-	ProjectService   packngo.ProjectService
+	ProjectService   metal.ProjectsApiService
 	BGPConfigService packngo.BGPConfigService
 
 	Out outputs.Outputer
@@ -47,7 +48,7 @@ func (c *Client) NewCommand() *cobra.Command {
 					root.PersistentPreRun(cmd, args)
 				}
 			}
-			c.ProjectService = c.Servicer.API(cmd).Projects
+			c.ProjectService = *c.Servicer.MetalAPI(cmd).ProjectsApi
 			c.BGPConfigService = c.Servicer.API(cmd).BGPConfig
 		},
 	}
@@ -65,6 +66,7 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
+	MetalAPI(*cobra.Command) *metal.APIClient
 	API(*cobra.Command) *packngo.Client
 	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
 	Format() outputs.Format

--- a/internal/projects/update.go
+++ b/internal/projects/update.go
@@ -23,7 +23,7 @@ package projects
 import (
 	"fmt"
 
-	"github.com/packethost/packngo"
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -42,22 +42,22 @@ func (c *Client) Update() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			req := &packngo.ProjectUpdateRequest{}
+			req := metal.NewProjectUpdateInput()
 			if name != "" {
 				req.Name = &name
 			}
 
 			if paymentMethodID != "" {
-				req.PaymentMethodID = &paymentMethodID
+				req.PaymentMethodId = &paymentMethodID
 			}
-			p, _, err := c.ProjectService.Update(projectID, req)
+			p, _, err := c.ProjectService.UpdateProject(cmd.Context(), projectID).ProjectUpdateInput(*req).Execute()
 			if err != nil {
 				return fmt.Errorf("Could not update Project: %w", err)
 			}
 
 			data := make([][]string, 1)
 
-			data[0] = []string{p.ID, p.Name, p.Created}
+			data[0] = []string{p.GetId(), p.GetName(), p.GetCreatedAt().String()}
 			header := []string{"ID", "Name", "Created"}
 			return c.Out.Output(p, header, &data)
 		},


### PR DESCRIPTION
What this PR does / why we need it:

This PR replaces packngo with metal-go for all interactions with the Equinix Metal API specifically for projects sub-commands 