### PR TITLE
Updated metal-go client for sub-command devices

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -48,6 +48,6 @@ jobs:
     - name: Get dependencies
       run: go mod download
     - name: Run end-to-end tests
-      run: go test -v -cover -coverpkg=./... -parallel 4 ./test/e2e/...
+      run: go test -v -cover -coverpkg=./... -parallel 4 ./test/e2e/... -timeout 1000s
       env:
         METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ generate-docs: clean-docs
 	go run ./cmd/metal docs ./docs
 
 test:
-	go test -v ./...
+	go test -v ./... -timeout 1000s
 
 
 ## --------------------------------------

--- a/docs/metal_device_create.md
+++ b/docs/metal_device_create.md
@@ -24,7 +24,7 @@ metal device create -p <project_id> (-m <metro> | -f <facility>) -P <plan> -H <h
 
 ```
   -a, --always-pxe                       Sets whether the device always PXE boots on reboot.
-  -b, --billing-cycle string             Billing cycle (default "hourly")
+  -b, --billing-cycle string             Billing cycle  (default "hourly")
   -c, --customdata string                Custom data to be included with your device's metadata.
   -f, --facility string                  Code of the facility where the device will be created
   -r, --hardware-reservation-id string   The UUID of a hardware reservation, if you are provisioning a server from your reserved hardware.
@@ -39,7 +39,7 @@ metal device create -p <project_id> (-m <metro> | -f <facility>) -P <plan> -H <h
   -s, --spot-instance                    Provisions the device as a spot instance.
       --spot-price-max float             Sets the maximum spot market price for the device: --spot-price-max=1.2
   -t, --tags strings                     Tag or list of tags for the device: --tags="tag1,tag2".
-  -T, --termination-time string          Device termination time: --termination-time="15:04:05"
+  -T, --termination-time string          Device termination time: --termination-time="2023-08-24T15:04:05Z"
   -u, --userdata string                  Userdata for device initialization. Can not be used with --userdata-file.
       --userdata-file string             Path to a userdata file for device initialization. Can not be used with --userdata.
 ```

--- a/internal/devices/delete.go
+++ b/internal/devices/delete.go
@@ -21,6 +21,7 @@
 package devices
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/manifoldco/promptui"
@@ -31,7 +32,7 @@ func (c *Client) Delete() *cobra.Command {
 	var deviceID string
 	var force bool
 	deleteDevice := func(id string) error {
-		_, err := c.Service.Delete(id, force)
+		_, err := c.Service.DeleteDevice(context.Background(), id).ForceDelete(force).Execute()
 		if err != nil {
 			return err
 		}

--- a/internal/devices/device.go
+++ b/internal/devices/device.go
@@ -21,15 +21,15 @@
 package devices
 
 import (
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/equinix/metal-cli/internal/outputs"
-	"github.com/packethost/packngo"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 type Client struct {
 	Servicer Servicer
-	Service  packngo.DeviceService
+	Service  metal.DevicesApiService
 	Out      outputs.Outputer
 }
 
@@ -47,7 +47,7 @@ func (c *Client) NewCommand() *cobra.Command {
 				}
 			}
 
-			c.Service = c.Servicer.API(cmd).Devices
+			c.Service = *c.Servicer.MetalAPI(cmd).DevicesApi
 		},
 	}
 
@@ -65,9 +65,11 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API(*cobra.Command) *packngo.Client
-	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
+	MetalAPI(*cobra.Command) *metal.APIClient
 	Config(cmd *cobra.Command) *viper.Viper
+	Filters() map[string]string
+	Includes(defaultIncludes []string) (incl []string)
+	Excludes(defaultExcludes []string) (excl []string)
 }
 
 func NewClient(s Servicer, out outputs.Outputer) *Client {

--- a/internal/devices/reboot.go
+++ b/internal/devices/reboot.go
@@ -21,8 +21,10 @@
 package devices
 
 import (
+	"context"
 	"fmt"
 
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +40,8 @@ func (c *Client) Reboot() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			_, err := c.Service.Reboot(deviceID)
+			DeviceAction := metal.NewDeviceActionInput("reboot")
+			_, err := c.Service.PerformAction(context.Background(), deviceID).DeviceActionInput(*DeviceAction).Execute()
 			if err != nil {
 				return fmt.Errorf("Could not reboot Device: %w", err)
 			}

--- a/internal/devices/reinstall.go
+++ b/internal/devices/reinstall.go
@@ -21,9 +21,10 @@
 package devices
 
 import (
+	"context"
 	"fmt"
 
-	"github.com/packethost/packngo"
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -47,14 +48,30 @@ func (c *Client) Reinstall() *cobra.Command {
   metal device reinstall -d 50382f72-02b7-4b40-ac8d-253713e1e174 -O ubuntu_22_04 --preserve-data`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			request := packngo.DeviceReinstallFields{
-				OperatingSystem: operatingSystem,
-				PreserveData:    preserveData,
-				DeprovisionFast: deprovisionFast,
+			DeviceAction := metal.NewDeviceActionInput("reinstall")
+
+			if preserveData {
+				DeviceAction.PreserveData = &preserveData
+			}
+			if deprovisionFast {
+				DeviceAction.DeprovisionFast = &deprovisionFast
+			}
+			device, _, Err := c.Service.FindDeviceById(context.Background(), id).Execute()
+			if Err != nil {
+				fmt.Printf("Error when calling `DevicesApiService.FindDeviceByID``: %v\n", Err)
+				Err = fmt.Errorf("Could not reinstall Device: %w", Err)
+				return Err
 			}
 
-			_, err := c.Service.Reinstall(id, &request)
+			if operatingSystem == "" || operatingSystem == "null" {
+				DeviceAction.SetOperatingSystem(device.OperatingSystem.GetSlug())
+			} else {
+				DeviceAction.OperatingSystem = &operatingSystem
+			}
+
+			_, err := c.Service.PerformAction(context.Background(), id).DeviceActionInput(*DeviceAction).Execute()
 			if err != nil {
+				fmt.Printf("Error when calling `DevicesApiService.PerformAction``: %v\n", err)
 				err = fmt.Errorf("Could not reinstall Device: %w", err)
 			}
 

--- a/internal/devices/start.go
+++ b/internal/devices/start.go
@@ -21,8 +21,10 @@
 package devices
 
 import (
+	"context"
 	"fmt"
 
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +40,8 @@ func (c *Client) Start() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			_, err := c.Service.PowerOn(deviceID)
+			DeviceAction := metal.NewDeviceActionInput("power_on")
+			_, err := c.Service.PerformAction(context.Background(), deviceID).DeviceActionInput(*DeviceAction).Execute()
 			if err != nil {
 				return fmt.Errorf("Could not start Device: %w", err)
 			}

--- a/internal/devices/stop.go
+++ b/internal/devices/stop.go
@@ -21,8 +21,10 @@
 package devices
 
 import (
+	"context"
 	"fmt"
 
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +39,8 @@ func (c *Client) Stop() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			_, err := c.Service.PowerOff(deviceID)
+			DeviceAction := metal.NewDeviceActionInput("power_off")
+			_, err := c.Service.PerformAction(context.Background(), deviceID).DeviceActionInput(*DeviceAction).Execute()
 			if err != nil {
 				return fmt.Errorf("Could not stop Device: %w", err)
 			}

--- a/internal/devices/update.go
+++ b/internal/devices/update.go
@@ -42,7 +42,6 @@ func (c *Client) Update() *cobra.Command {
 		customdata    string
 		deviceID      string
 	)
-
 	// updateDeviceCmd represents the updateDevice command
 	updateDeviceCmd := &cobra.Command{
 		Use:   `update -i <device_id> [-H <hostname>] [-d <description>] [--locked <boolean>] [-t <tags>] [-u <userdata>] [-c <customdata>] [-s <ipxe_script_url>] [--always-pxe]`,
@@ -76,7 +75,7 @@ func (c *Client) Update() *cobra.Command {
 			}
 
 			if alwaysPXE {
-				deviceUpdate.AlwaysPxe = &alwaysPXE
+				deviceUpdate.SetAlwaysPxe(alwaysPXE)
 			}
 
 			if ipxescripturl != "" {
@@ -114,7 +113,7 @@ func (c *Client) Update() *cobra.Command {
 	updateDeviceCmd.Flags().BoolVarP(&alwaysPXE, "always-pxe", "a", false, "Sets the device to always iPXE on reboot.")
 	updateDeviceCmd.Flags().StringVarP(&ipxescripturl, "ipxe-script-url", "s", "", "Add or update the URL of the iPXE script.")
 	updateDeviceCmd.Flags().StringVarP(&customdata, "customdata", "c", "", "Adds or updates custom data to be included with your device's metadata.")
-
 	_ = updateDeviceCmd.MarkFlagRequired("id")
+
 	return updateDeviceCmd
 }

--- a/internal/pagination/pager.go
+++ b/internal/pagination/pager.go
@@ -127,3 +127,22 @@ func GetAllOrganizations(s metal.OrganizationsApiService, include, exclude []str
 		return orgs, nil
 	}
 }
+
+func GetProjectDevices(s metal.ApiFindProjectDevicesRequest) ([]metal.Device, error) {
+	var devices []metal.Device
+
+	page := int32(1)     // int32 | Page to return (optional) (default to 1)
+	perPage := int32(20) // int32 | Items returned per page (optional) (default to 10)
+	for {
+		devicePage, _, err := s.Page(page).PerPage(perPage).Execute()
+		if err != nil {
+			return nil, err
+		}
+		devices = append(devices, devicePage.Devices...)
+		if devicePage.Meta.GetLastPage() > devicePage.Meta.GetCurrentPage() {
+			page = page + 1
+			continue
+		}
+		return devices, nil
+	}
+}

--- a/test/e2e/capacitytest/capacity_test.go
+++ b/test/e2e/capacitytest/capacity_test.go
@@ -1,4 +1,4 @@
-package e2e
+package capacitytest
 
 import (
 	"io"

--- a/test/e2e/devices/devicecreateflagstest/device_create_flags_test.go
+++ b/test/e2e/devices/devicecreateflagstest/device_create_flags_test.go
@@ -1,4 +1,4 @@
-package devicecreatetest
+package devicecreateflagstest
 
 import (
 	"io"
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func TestCli_Devices_Create(t *testing.T) {
+func TestCli_Devices_Create_Flags(t *testing.T) {
 	var projectId, deviceId string
 	var err error
 	var resp bool
@@ -42,13 +42,13 @@ func TestCli_Devices_Create(t *testing.T) {
 			want: &cobra.Command{},
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
-				projectId, err = helper.CreateTestProject("metal-cli-create-pro")
+				projectId, err = helper.CreateTestProject("metal-cli-create-flags-pro")
 				if err != nil {
 					t.Error(err)
 				}
 				if len(projectId) != 0 {
 
-					root.SetArgs([]string{subCommand, "create", "-p", projectId, "-P", "m3.small.x86", "-m", "da", "-O", "ubuntu_20_04", "-H", "metal-cli-create-dev"})
+					root.SetArgs([]string{subCommand, "create", "-p", projectId, "-P", "m3.small.x86", "-m", "da", "-H", "metal-cli-create-flags-dev", "--operating-system", "custom_ipxe", "--always-pxe=true", "--ipxe-script-url", "https://boot.netboot.xyz/"})
 					rescueStdout := os.Stdout
 					r, w, _ := os.Pipe()
 					os.Stdout = w
@@ -58,12 +58,12 @@ func TestCli_Devices_Create(t *testing.T) {
 					w.Close()
 					out, _ := io.ReadAll(r)
 					os.Stdout = rescueStdout
-					if !strings.Contains(string(out[:]), "metal-cli-create-dev") &&
+					if !strings.Contains(string(out[:]), "metal-cli-create-flags-dev") &&
 						!strings.Contains(string(out[:]), "Ubuntu 20.04 LTS") &&
 						!strings.Contains(string(out[:]), "queued") {
-						t.Error("expected output should include metal-cli-create-dev, Ubuntu 20.04 LTS, and queued strings in the out string ")
+						t.Error("expected output should include metal-cli-create-flags-dev, Ubuntu 20.04 LTS, and queued strings in the out string ")
 					}
-					name := "metal-cli-create-dev"
+					name := "metal-cli-create-flags-dev"
 					idNamePattern := `(?m)^\| ([a-zA-Z0-9-]+) +\| *` + name + ` *\|`
 
 					// Find the match of the ID and NAME pattern in the table string
@@ -73,10 +73,7 @@ func TestCli_Devices_Create(t *testing.T) {
 					if len(match) > 1 {
 						deviceId = strings.TrimSpace(match[1])
 						resp, err = helper.IsDeviceStateActive(deviceId)
-						if err != nil || resp {
-							if !resp {
-								resp, err = helper.IsDeviceStateActive(deviceId)
-							}
+						if err == nil && resp == true {
 							err = helper.CleanTestDevice(deviceId)
 							if err != nil {
 								t.Error(err)
@@ -85,6 +82,8 @@ func TestCli_Devices_Create(t *testing.T) {
 							if err != nil {
 								t.Error(err)
 							}
+						} else {
+							t.Error(err)
 						}
 					}
 				}

--- a/test/e2e/devices/devicecreatetest/device_create_test.go
+++ b/test/e2e/devices/devicecreatetest/device_create_test.go
@@ -1,0 +1,87 @@
+package devicecreatetest
+
+import (
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	root "github.com/equinix/metal-cli/internal/cli"
+	"github.com/equinix/metal-cli/internal/devices"
+	outputPkg "github.com/equinix/metal-cli/internal/outputs"
+	"github.com/equinix/metal-cli/test/helper"
+	"github.com/spf13/cobra"
+)
+
+func TestCli_Devices_create(t *testing.T) {
+	var projectId, deviceId string
+	subCommand := "device"
+	consumerToken := ""
+	apiURL := ""
+	Version := "metal"
+	rootClient := root.NewClient(consumerToken, apiURL, Version)
+	type fields struct {
+		MainCmd  *cobra.Command
+		Outputer outputPkg.Outputer
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    *cobra.Command
+		cmdFunc func(*testing.T, *cobra.Command)
+	}{
+		{
+			name: "create_device",
+			fields: fields{
+				MainCmd:  devices.NewClient(rootClient, outputPkg.Outputer(&outputPkg.Standard{})).NewCommand(),
+				Outputer: outputPkg.Outputer(&outputPkg.Standard{}),
+			},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				projectId = helper.Create_test_project("create-device-pro")
+				if len(projectId) != 0 {
+
+					root.SetArgs([]string{subCommand, "create", "-p", projectId, "-P", "c3.small.x86", "-m", "da", "-O", "ubuntu_20_04", "-H", "create-device-dev"})
+					rescueStdout := os.Stdout
+					r, w, _ := os.Pipe()
+					os.Stdout = w
+					if err := root.Execute(); err != nil {
+						t.Error(err)
+					}
+					w.Close()
+					out, _ := io.ReadAll(r)
+					os.Stdout = rescueStdout
+					if !strings.Contains(string(out[:]), "create-device-dev") &&
+						!strings.Contains(string(out[:]), "Ubuntu 20.04 LTS") &&
+						!strings.Contains(string(out[:]), "queued") {
+						t.Error("expected output should include create-device-dev, Ubuntu 20.04 LTS, and queued strings in the out string ")
+					}
+					name := "create-device-dev"
+					idNamePattern := `(?m)^\| ([a-zA-Z0-9-]+) +\| *` + name + ` *\|`
+
+					// Find the match of the ID and NAME pattern in the table string
+					match := regexp.MustCompile(idNamePattern).FindStringSubmatch(string(out[:]))
+
+					// Extract the ID from the match
+					if len(match) > 1 {
+						deviceId = strings.TrimSpace(match[1])
+						if helper.Is_Device_state_active(deviceId) {
+							helper.Clean_test_device(deviceId)
+							helper.Clean_test_project(projectId)
+						}
+					}
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd := rootClient.NewCommand()
+			rootCmd.AddCommand(tt.fields.MainCmd)
+			tt.cmdFunc(t, tt.fields.MainCmd)
+		})
+	}
+}

--- a/test/e2e/devices/devicereinstalltest/device_reinstall_test.go
+++ b/test/e2e/devices/devicereinstalltest/device_reinstall_test.go
@@ -1,9 +1,6 @@
-package devicestest
+package devicereinstalltest
 
 import (
-	"io"
-	"os"
-	"strings"
 	"testing"
 
 	root "github.com/equinix/metal-cli/internal/cli"
@@ -13,10 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func TestCli_Devices_Get(t *testing.T) {
+func TestCli_Devices_Update(t *testing.T) {
 	var projectId, deviceId string
 	var err error
-	var resp bool
+	var status bool
 	subCommand := "device"
 	consumerToken := ""
 	apiURL := ""
@@ -33,7 +30,7 @@ func TestCli_Devices_Get(t *testing.T) {
 		cmdFunc func(*testing.T, *cobra.Command)
 	}{
 		{
-			name: "get_by_device_id",
+			name: "reinstall_device",
 			fields: fields{
 				MainCmd:  devices.NewClient(rootClient, outputPkg.Outputer(&outputPkg.Standard{})).NewCommand(),
 				Outputer: outputPkg.Outputer(&outputPkg.Standard{}),
@@ -41,40 +38,46 @@ func TestCli_Devices_Get(t *testing.T) {
 			want: &cobra.Command{},
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
-				projectId, err = helper.CreateTestProject("metal-cli-get-pro")
+				projectId, err = helper.CreateTestProject("metal-cli-reinstall-pro")
 				if err != nil {
 					t.Error(err)
 				}
-				deviceId, err = helper.CreateTestDevice(projectId, "metal-cli-get-dev")
+				deviceId, err = helper.CreateTestDevice(projectId, "metal-cli-reinstall-dev")
 				if err != nil {
 					t.Error(err)
 				}
-				root.SetArgs([]string{subCommand, "get", "-i", deviceId})
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				if err := root.Execute(); err != nil {
-					t.Error(err)
-				}
-				w.Close()
-				out, _ := io.ReadAll(r)
-				os.Stdout = rescueStdout
-				if !strings.Contains(string(out[:]), deviceId) {
-					t.Error("expected output should include " + deviceId)
-				}
-				if len(projectId) != 0 && len(deviceId) != 0 {
-					resp, err = helper.IsDeviceStateActive(deviceId)
-					if err == nil && resp == true {
-						err = helper.CleanTestDevice(deviceId)
-						if err != nil {
-							t.Error(err)
-						}
-						err = helper.CleanTestProject(projectId)
-						if err != nil {
-							t.Error(err)
-						}
-					} else {
+				status, err = helper.IsDeviceStateActive(deviceId)
+				if err != nil {
+					status, err = helper.IsDeviceStateActive(deviceId)
+					if err != nil {
 						t.Error(err)
+					}
+				}
+
+				if len(projectId) != 0 && len(deviceId) != 0 && status {
+					root.SetArgs([]string{subCommand, "reinstall", "--id", deviceId, "-O", "ubuntu_22_04", "--preserve-data"})
+					err = root.Execute()
+					if err != nil {
+						t.Error(err)
+					} else {
+						status, err = helper.IsDeviceStateActive(deviceId)
+						// The below case will excute in both Device Active and Non-active states.
+						if err != nil || status {
+							if !status {
+								_, err = helper.IsDeviceStateActive(deviceId)
+								if err != nil {
+									t.Error(err)
+								}
+							}
+							err = helper.CleanTestDevice(deviceId)
+							if err != nil {
+								t.Error(err)
+							}
+							err = helper.CleanTestProject(projectId)
+							if err != nil {
+								t.Error(err)
+							}
+						}
 					}
 				}
 			},

--- a/test/e2e/devices/deviceupdatetest/device_update_test.go
+++ b/test/e2e/devices/deviceupdatetest/device_update_test.go
@@ -1,4 +1,4 @@
-package devicestest
+package deviceupdatetest
 
 import (
 	"io"
@@ -13,10 +13,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func TestCli_Devices_Get(t *testing.T) {
+func TestCli_Devices_Update(t *testing.T) {
 	var projectId, deviceId string
 	var err error
-	var resp bool
 	subCommand := "device"
 	consumerToken := ""
 	apiURL := ""
@@ -33,7 +32,7 @@ func TestCli_Devices_Get(t *testing.T) {
 		cmdFunc func(*testing.T, *cobra.Command)
 	}{
 		{
-			name: "get_by_device_id",
+			name: "update_device",
 			fields: fields{
 				MainCmd:  devices.NewClient(rootClient, outputPkg.Outputer(&outputPkg.Standard{})).NewCommand(),
 				Outputer: outputPkg.Outputer(&outputPkg.Standard{}),
@@ -41,39 +40,39 @@ func TestCli_Devices_Get(t *testing.T) {
 			want: &cobra.Command{},
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
-				projectId, err = helper.CreateTestProject("metal-cli-get-pro")
+				projectId, err = helper.CreateTestProject("metal-cli-update-pro")
 				if err != nil {
 					t.Error(err)
 				}
-				deviceId, err = helper.CreateTestDevice(projectId, "metal-cli-get-dev")
+				deviceId, err = helper.CreateTestDevice(projectId, "metal-cli-update-dev")
 				if err != nil {
 					t.Error(err)
 				}
-				root.SetArgs([]string{subCommand, "get", "-i", deviceId})
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				if err := root.Execute(); err != nil {
+				status, err := helper.IsDeviceStateActive(deviceId)
+				if err != nil {
 					t.Error(err)
 				}
-				w.Close()
-				out, _ := io.ReadAll(r)
-				os.Stdout = rescueStdout
-				if !strings.Contains(string(out[:]), deviceId) {
-					t.Error("expected output should include " + deviceId)
-				}
-				if len(projectId) != 0 && len(deviceId) != 0 {
-					resp, err = helper.IsDeviceStateActive(deviceId)
-					if err == nil && resp == true {
-						err = helper.CleanTestDevice(deviceId)
-						if err != nil {
-							t.Error(err)
-						}
-						err = helper.CleanTestProject(projectId)
-						if err != nil {
-							t.Error(err)
-						}
-					} else {
+				if len(projectId) != 0 && len(deviceId) != 0 && status == true {
+					root.SetArgs([]string{subCommand, "update", "-i", deviceId, "-H", "metal-cli-update-dev-test", "-d", "This device used for testing"})
+					rescueStdout := os.Stdout
+					r, w, _ := os.Pipe()
+					os.Stdout = w
+					if err := root.Execute(); err != nil {
+						t.Error(err)
+					}
+					w.Close()
+					out, _ := io.ReadAll(r)
+					os.Stdout = rescueStdout
+					if !strings.Contains(string(out[:]), "metal-cli-update-dev-test") {
+						t.Error("expected output should include metal-cli-update-dev-test in the out string ")
+					}
+
+					err = helper.CleanTestDevice(deviceId)
+					if err != nil {
+						t.Error(err)
+					}
+					err = helper.CleanTestProject(projectId)
+					if err != nil {
 						t.Error(err)
 					}
 				}

--- a/test/e2e/metrotest/metro_test.go
+++ b/test/e2e/metrotest/metro_test.go
@@ -1,4 +1,4 @@
-package e2e
+package metrotest
 
 import (
 	"io"

--- a/test/e2e/organizationtest/organization_test.go
+++ b/test/e2e/organizationtest/organization_test.go
@@ -1,4 +1,4 @@
-package e2e
+package organizationtest
 
 import (
 	"testing"

--- a/test/e2e/ostest/os_test.go
+++ b/test/e2e/ostest/os_test.go
@@ -1,4 +1,4 @@
-package e2e
+package ostest
 
 import (
 	"io"

--- a/test/e2e/plantest/plan_test.go
+++ b/test/e2e/plantest/plan_test.go
@@ -1,4 +1,4 @@
-package e2e
+package plantest
 
 import (
 	"io"

--- a/test/e2e/usertest/user_test.go
+++ b/test/e2e/usertest/user_test.go
@@ -1,4 +1,4 @@
-package e2e
+package usertest
 
 import (
 	"io"

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -1,0 +1,95 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	openapiclient "github.com/equinix-labs/metal-go/metal/v1"
+)
+
+func TestClient() *openapiclient.APIClient {
+	configuration := openapiclient.NewConfiguration()
+	configuration.AddDefaultHeader("X-Auth-Token", os.Getenv("METAL_AUTH_TOKEN"))
+	apiClient := openapiclient.NewAPIClient(configuration)
+	return apiClient
+}
+
+func Create_test_project(name string) string {
+	TestApiClient := TestClient()
+
+	projectCreateFromRootInput := *openapiclient.NewProjectCreateFromRootInput(name) // ProjectCreateFromRootInput | Project to create
+	include := []string{"Inner_example"}
+	exclude := []string{"Inner_example"}
+
+	projectResp, r, err := TestApiClient.ProjectsApi.CreateProject(context.Background()).ProjectCreateFromRootInput(projectCreateFromRootInput).Include(include).Exclude(exclude).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `ProjectsApi.CreateProject``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+		return ""
+	}
+	return projectResp.GetId()
+}
+
+func Create_test_device(projectId, name string) string {
+	include := []string{"Inner_example"}
+	exclude := []string{"Inner_example"}
+
+	TestApiClient := TestClient()
+
+	hostname := name
+	metroDeviceRequest := openapiclient.CreateDeviceRequest{
+		DeviceCreateInMetroInput: &openapiclient.DeviceCreateInMetroInput{
+			Metro:           "da",
+			Plan:            "c3.small.x86",
+			OperatingSystem: "ubuntu_20_04",
+			Hostname:        &hostname,
+		},
+	}
+	deviceResp, _, err := TestApiClient.DevicesApi.CreateDevice(context.Background(), projectId).CreateDeviceRequest(metroDeviceRequest).Include(include).Exclude(exclude).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `DevicesApi.CreateDevice``: %v\n", err)
+		return ""
+	}
+	return deviceResp.GetId()
+}
+
+func Is_Device_state_active(deviceId string) bool {
+	TestApiClient := TestClient()
+	predefinedTime := 200 * time.Second // Adjust this as needed
+	retryInterval := 10 * time.Second   // Adjust this as needed
+	startTime := time.Now()
+	for time.Since(startTime) < predefinedTime {
+		resp, _, err := TestApiClient.DevicesApi.FindDeviceById(context.Background(), deviceId).Execute()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error when calling `DevicesApi.FindDeviceById``: %v\n", err)
+		}
+		if resp.GetState() == "active" {
+			return true
+		}
+
+		// Sleep for the specified interval
+		time.Sleep(retryInterval)
+	}
+	return false
+}
+
+func Clean_test_device(deviceId string) {
+	forceDelete := true // bool | Force the deletion of the device, by detaching any storage volume still active. (optional)
+
+	TestApiClient := TestClient()
+	_, err := TestApiClient.DevicesApi.DeleteDevice(context.Background(), deviceId).ForceDelete(forceDelete).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `DevicesApi.DeleteDevice``: %v\n", err)
+	}
+}
+
+func Clean_test_project(projectId string) {
+	TestApiClient := TestClient()
+	r, err := TestApiClient.ProjectsApi.DeleteProject(context.Background(), projectId).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `ProjectsApi.DeleteProject``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+}

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -16,80 +16,96 @@ func TestClient() *openapiclient.APIClient {
 	return apiClient
 }
 
-func Create_test_project(name string) string {
+// func Create_test_project(name string) string {
+func CreateTestProject(name string) (string, error) {
 	TestApiClient := TestClient()
 
 	projectCreateFromRootInput := *openapiclient.NewProjectCreateFromRootInput(name) // ProjectCreateFromRootInput | Project to create
-	include := []string{"Inner_example"}
-	exclude := []string{"Inner_example"}
 
-	projectResp, r, err := TestApiClient.ProjectsApi.CreateProject(context.Background()).ProjectCreateFromRootInput(projectCreateFromRootInput).Include(include).Exclude(exclude).Execute()
+	projectResp, r, err := TestApiClient.ProjectsApi.CreateProject(context.Background()).ProjectCreateFromRootInput(projectCreateFromRootInput).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `ProjectsApi.CreateProject``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-		return ""
+		return "", err
 	}
-	return projectResp.GetId()
+	return projectResp.GetId(), nil
 }
 
-func Create_test_device(projectId, name string) string {
-	include := []string{"Inner_example"}
-	exclude := []string{"Inner_example"}
-
+func CreateTestDevice(projectId, name string) (string, error) {
 	TestApiClient := TestClient()
 
 	hostname := name
 	metroDeviceRequest := openapiclient.CreateDeviceRequest{
 		DeviceCreateInMetroInput: &openapiclient.DeviceCreateInMetroInput{
 			Metro:           "da",
-			Plan:            "c3.small.x86",
+			Plan:            "m3.small.x86",
 			OperatingSystem: "ubuntu_20_04",
 			Hostname:        &hostname,
 		},
 	}
-	deviceResp, _, err := TestApiClient.DevicesApi.CreateDevice(context.Background(), projectId).CreateDeviceRequest(metroDeviceRequest).Include(include).Exclude(exclude).Execute()
+	deviceResp, _, err := TestApiClient.DevicesApi.CreateDevice(context.Background(), projectId).CreateDeviceRequest(metroDeviceRequest).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `DevicesApi.CreateDevice``: %v\n", err)
-		return ""
+		return "", err
 	}
-	return deviceResp.GetId()
+	return deviceResp.GetId(), nil
 }
 
-func Is_Device_state_active(deviceId string) bool {
+func IsDeviceStateActive(deviceId string) (bool, error) {
+	var err error
+	var resp *openapiclient.Device
 	TestApiClient := TestClient()
-	predefinedTime := 200 * time.Second // Adjust this as needed
+	predefinedTime := 500 * time.Second // Adjust this as needed
 	retryInterval := 10 * time.Second   // Adjust this as needed
 	startTime := time.Now()
 	for time.Since(startTime) < predefinedTime {
-		resp, _, err := TestApiClient.DevicesApi.FindDeviceById(context.Background(), deviceId).Execute()
+		resp, _, err = TestApiClient.DevicesApi.FindDeviceById(context.Background(), deviceId).Execute()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error when calling `DevicesApi.FindDeviceById``: %v\n", err)
+			return false, err
 		}
 		if resp.GetState() == "active" {
-			return true
+			return true, nil
 		}
 
 		// Sleep for the specified interval
 		time.Sleep(retryInterval)
 	}
-	return false
+	return false, err
 }
 
-func Clean_test_device(deviceId string) {
+func StopTestDevice(deviceId string) error {
+
+	deviceActionInput := *openapiclient.NewDeviceActionInput("power_off")
+	TestApiClient := TestClient()
+
+	_, err := TestApiClient.DevicesApi.PerformAction(context.Background(), deviceId).DeviceActionInput(deviceActionInput).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `DevicesApi.PerformAction``: %v\n", err)
+		return err
+	}
+	return nil
+}
+
+func CleanTestDevice(deviceId string) error {
 	forceDelete := true // bool | Force the deletion of the device, by detaching any storage volume still active. (optional)
 
 	TestApiClient := TestClient()
 	_, err := TestApiClient.DevicesApi.DeleteDevice(context.Background(), deviceId).ForceDelete(forceDelete).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `DevicesApi.DeleteDevice``: %v\n", err)
+		return err
 	}
+	return nil
 }
 
-func Clean_test_project(projectId string) {
+func CleanTestProject(projectId string) error {
 	TestApiClient := TestClient()
 	r, err := TestApiClient.ProjectsApi.DeleteProject(context.Background(), projectId).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `ProjectsApi.DeleteProject``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+		return err
 	}
+	return nil
 }


### PR DESCRIPTION
Breakout from https://github.com/equinix/metal-cli/pull/270

What this PR does / why we need it:

This PR replaces packngo with metal-go for all interactions with the Equinix Metal API specifically for Device sub commands

Test Results:
================
# Retrieve
## Cmd: metal devices get

* Packngo:
```
vasu@vasu-cloud:~/Equinix$ metal devices get
+--------------------------------------+-------------------------------------+------------------+--------+----------------------+
|                  ID                  |              HOSTNAME               |        OS        | STATE  |       CREATED        |
+--------------------------------------+-------------------------------------+------------------+--------+----------------------+
| d231a5d0-3da9-4e4b-bbd6-a367c4c2d34b | test-staging-2                      | Ubuntu 20.04 LTS | active | 2023-06-01T08:42:42Z |
| bcab4df0-945e-4cb5-a8c7-f9dfbaabb3d7 | eksa-node-003                       | Custom iPXE      | active | 2023-04-25T12:33:17Z |
| 09be98b7-0db6-4fdb-90be-901ab847158d | test-packngo                        | Ubuntu 20.04 LTS | active | 2023-06-26T13:09:24Z |
| b396c4fd-c412-4a25-b6b4-df6f2f548629 | test-staging-12                     | Ubuntu 22.04 LTS | active | 2023-06-01T08:43:12Z |
| bad6f156-4777-49a5-87e7-d038e7365c9e | capi-quickstart-control-plane-mkz7l | Ubuntu 22.04 LTS | active | 2023-05-03T09:42:52Z |
| d7126b67-a96f-48b7-9cf1-e1914d84235b | capi-quickstart-worker-a-spr64      | Ubuntu 22.04 LTS | active | 2023-05-03T09:48:01Z |
| 4c397b2d-eccf-4948-9fcf-2b325303048c | capi-quickstart-control-plane-98xjq | Ubuntu 22.04 LTS | active | 2023-05-03T09:48:05Z |
| bdbe09fa-d140-4cc9-b988-f51610e8c2f3 | capi-quickstart-worker-a-q89f8      | Ubuntu 22.04 LTS | active | 2023-05-03T09:47:59Z |
| 67992861-066b-4d76-a6a4-a21b3e855722 | capi-quickstart-worker-a-qqnhb      | Ubuntu 22.04 LTS | active | 2023-05-03T09:48:00Z |
| b15870cd-a83d-48bd-9552-5281162ae563 | capi-quickstart-control-plane-lxnsr | Ubuntu 22.04 LTS | active | 2023-05-03T09:54:11Z |
| 2f6d7ff2-6aa5-49bc-838a-97a3473ea16a | eksa-node-002                       | Custom iPXE      | active | 2023-04-24T18:24:15Z |
| 46005014-5256-41b3-938a-1b295f931aa2 | eksa-node-001                       | Custom iPXE      | active | 2023-04-24T18:24:12Z |
| c3b1006c-0422-4f01-9c96-24dbcd72f7f1 | eksa-admin                          | Ubuntu 20.04 LTS | active | 2023-04-24T18:22:35Z |
+--------------------------------------+-------------------------------------+------------------+--------+----------------------+
```
* Metal-Go
```
vasu@vasu-cloud:~/Equinix$ metal devices get
+--------------------------------------+-------------------------------------+------------------+--------+----------------------+
|                  ID                  |              HOSTNAME               |        OS        | STATE  |       CREATED        |
+--------------------------------------+-------------------------------------+------------------+--------+----------------------+
| d231a5d0-3da9-4e4b-bbd6-a367c4c2d34b | test-staging-2                      | Ubuntu 20.04 LTS | active | 2023-06-01T08:42:42Z |
| bcab4df0-945e-4cb5-a8c7-f9dfbaabb3d7 | eksa-node-003                       | Custom iPXE      | active | 2023-04-25T12:33:17Z |
| 09be98b7-0db6-4fdb-90be-901ab847158d | test-packngo                        | Ubuntu 20.04 LTS | active | 2023-06-26T13:09:24Z |
| b396c4fd-c412-4a25-b6b4-df6f2f548629 | test-staging-12                     | Ubuntu 22.04 LTS | active | 2023-06-01T08:43:12Z |
| bad6f156-4777-49a5-87e7-d038e7365c9e | capi-quickstart-control-plane-mkz7l | Ubuntu 22.04 LTS | active | 2023-05-03T09:42:52Z |
| d7126b67-a96f-48b7-9cf1-e1914d84235b | capi-quickstart-worker-a-spr64      | Ubuntu 22.04 LTS | active | 2023-05-03T09:48:01Z |
| 4c397b2d-eccf-4948-9fcf-2b325303048c | capi-quickstart-control-plane-98xjq | Ubuntu 22.04 LTS | active | 2023-05-03T09:48:05Z |
| bdbe09fa-d140-4cc9-b988-f51610e8c2f3 | capi-quickstart-worker-a-q89f8      | Ubuntu 22.04 LTS | active | 2023-05-03T09:47:59Z |
| 67992861-066b-4d76-a6a4-a21b3e855722 | capi-quickstart-worker-a-qqnhb      | Ubuntu 22.04 LTS | active | 2023-05-03T09:48:00Z |
| b15870cd-a83d-48bd-9552-5281162ae563 | capi-quickstart-control-plane-lxnsr | Ubuntu 22.04 LTS | active | 2023-05-03T09:54:11Z |
| 2f6d7ff2-6aa5-49bc-838a-97a3473ea16a | eksa-node-002                       | Custom iPXE      | active | 2023-04-24T18:24:15Z |
| 46005014-5256-41b3-938a-1b295f931aa2 | eksa-node-001                       | Custom iPXE      | active | 2023-04-24T18:24:12Z |
| c3b1006c-0422-4f01-9c96-24dbcd72f7f1 | eksa-admin                          | Ubuntu 20.04 LTS | active | 2023-04-24T18:22:35Z |
+--------------------------------------+-------------------------------------+------------------+--------+----------------------+

```

## Cmd: metal devices get -p <Project_ID>
* Packngo:
```
vasu@vasu-cloud:~/Equinix$ metal devices get -p 65dcd8f4-abd4-4e7a-8b29-da4b030edd96
+--------------------------------------+-------------------------------------+------------------+--------+----------------------+
|                  ID                  |              HOSTNAME               |        OS        | STATE  |       CREATED        |
+--------------------------------------+-------------------------------------+------------------+--------+----------------------+
| d231a5d0-3da9-4e4b-bbd6-a367c4c2d34b | test-staging-2                      | Ubuntu 20.04 LTS | active | 2023-06-01T08:42:42Z |
| bcab4df0-945e-4cb5-a8c7-f9dfbaabb3d7 | eksa-node-003                       | Custom iPXE      | active | 2023-04-25T12:33:17Z |
| 09be98b7-0db6-4fdb-90be-901ab847158d | test-packngo                        | Ubuntu 20.04 LTS | active | 2023-06-26T13:09:24Z |
| b396c4fd-c412-4a25-b6b4-df6f2f548629 | test-staging-12                     | Ubuntu 22.04 LTS | active | 2023-06-01T08:43:12Z |
| bad6f156-4777-49a5-87e7-d038e7365c9e | capi-quickstart-control-plane-mkz7l | Ubuntu 22.04 LTS | active | 2023-05-03T09:42:52Z |
| d7126b67-a96f-48b7-9cf1-e1914d84235b | capi-quickstart-worker-a-spr64      | Ubuntu 22.04 LTS | active | 2023-05-03T09:48:01Z |
| 4c397b2d-eccf-4948-9fcf-2b325303048c | capi-quickstart-control-plane-98xjq | Ubuntu 22.04 LTS | active | 2023-05-03T09:48:05Z |
| bdbe09fa-d140-4cc9-b988-f51610e8c2f3 | capi-quickstart-worker-a-q89f8      | Ubuntu 22.04 LTS | active | 2023-05-03T09:47:59Z |
| 67992861-066b-4d76-a6a4-a21b3e855722 | capi-quickstart-worker-a-qqnhb      | Ubuntu 22.04 LTS | active | 2023-05-03T09:48:00Z |
| b15870cd-a83d-48bd-9552-5281162ae563 | capi-quickstart-control-plane-lxnsr | Ubuntu 22.04 LTS | active | 2023-05-03T09:54:11Z |
| 2f6d7ff2-6aa5-49bc-838a-97a3473ea16a | eksa-node-002                       | Custom iPXE      | active | 2023-04-24T18:24:15Z |
| 46005014-5256-41b3-938a-1b295f931aa2 | eksa-node-001                       | Custom iPXE      | active | 2023-04-24T18:24:12Z |
| c3b1006c-0422-4f01-9c96-24dbcd72f7f1 | eksa-admin                          | Ubuntu 20.04 LTS | active | 2023-04-24T18:22:35Z |
+--------------------------------------+-------------------------------------+------------------+--------+----------------------+
```
* Metal-Go
```
vasu@vasu-cloud:~/Equinix/metal-cli/bin$ ./metal devices get -p 65dcd8f4-abd4-4e7a-8b29-da4b030edd96
+--------------------------------------+-------------------------------------+------------------+--------+-------------------------------+
|                  ID                  |              HOSTNAME               |        OS        | STATE  |            CREATED            |
+--------------------------------------+-------------------------------------+------------------+--------+-------------------------------+
| d231a5d0-3da9-4e4b-bbd6-a367c4c2d34b | test-staging-2                      | Ubuntu 20.04 LTS | active | 2023-06-01 08:42:42 +0000 UTC |
| bcab4df0-945e-4cb5-a8c7-f9dfbaabb3d7 | eksa-node-003                       | Custom iPXE      | active | 2023-04-25 12:33:17 +0000 UTC |
| 09be98b7-0db6-4fdb-90be-901ab847158d | test-packngo                        | Ubuntu 20.04 LTS | active | 2023-06-26 13:09:24 +0000 UTC |
| b396c4fd-c412-4a25-b6b4-df6f2f548629 | test-staging-12                     | Ubuntu 22.04 LTS | active | 2023-06-01 08:43:12 +0000 UTC |
| bad6f156-4777-49a5-87e7-d038e7365c9e | capi-quickstart-control-plane-mkz7l | Ubuntu 22.04 LTS | active | 2023-05-03 09:42:52 +0000 UTC |
| d7126b67-a96f-48b7-9cf1-e1914d84235b | capi-quickstart-worker-a-spr64      | Ubuntu 22.04 LTS | active | 2023-05-03 09:48:01 +0000 UTC |
| 4c397b2d-eccf-4948-9fcf-2b325303048c | capi-quickstart-control-plane-98xjq | Ubuntu 22.04 LTS | active | 2023-05-03 09:48:05 +0000 UTC |
| bdbe09fa-d140-4cc9-b988-f51610e8c2f3 | capi-quickstart-worker-a-q89f8      | Ubuntu 22.04 LTS | active | 2023-05-03 09:47:59 +0000 UTC |
| 67992861-066b-4d76-a6a4-a21b3e855722 | capi-quickstart-worker-a-qqnhb      | Ubuntu 22.04 LTS | active | 2023-05-03 09:48:00 +0000 UTC |
| b15870cd-a83d-48bd-9552-5281162ae563 | capi-quickstart-control-plane-lxnsr | Ubuntu 22.04 LTS | active | 2023-05-03 09:54:11 +0000 UTC |
| 2f6d7ff2-6aa5-49bc-838a-97a3473ea16a | eksa-node-002                       | Custom iPXE      | active | 2023-04-24 18:24:15 +0000 UTC |
| 46005014-5256-41b3-938a-1b295f931aa2 | eksa-node-001                       | Custom iPXE      | active | 2023-04-24 18:24:12 +0000 UTC |
| c3b1006c-0422-4f01-9c96-24dbcd72f7f1 | eksa-admin                          | Ubuntu 20.04 LTS | active | 2023-04-24 18:22:35 +0000 UTC |
+--------------------------------------+-------------------------------------+------------------+--------+-------------------------------+
```

## Cmd: metal devices get -i <Device ID>
* Packngo:
```
vasu@vasu-cloud:~/Equinix$ metal devices get -i 09be98b7-0db6-4fdb-90be-901ab847158d
+--------------------------------------+--------------+------------------+--------+----------------------+
|                  ID                  |   HOSTNAME   |        OS        | STATE  |       CREATED        |
+--------------------------------------+--------------+------------------+--------+----------------------+
| 09be98b7-0db6-4fdb-90be-901ab847158d | test-packngo | Ubuntu 20.04 LTS | active | 2023-06-26T13:09:24Z |
+--------------------------------------+--------------+------------------+--------+----------------------+
```
*Metal-go:
```
vasu@vasu-cloud:~/Equinix/metal-cli/bin$ ./metal devices get -i 09be98b7-0db6-4fdb-90be-901ab847158d
+--------------------------------------+--------------+------------------+--------+-------------------------------+
|                  ID                  |   HOSTNAME   |        OS        | STATE  |            CREATED            |
+--------------------------------------+--------------+------------------+--------+-------------------------------+
| 09be98b7-0db6-4fdb-90be-901ab847158d | test-packngo | Ubuntu 20.04 LTS | active | 2023-06-26 13:09:24 +0000 UTC |
+--------------------------------------+--------------+------------------+--------+-------------------------------+
```
# Create

```
Vasubabus-MacBook-Pro:bin vasubabu$ ./metal device create -p c309ce2c-160d-47e2-bb26-9debeb0be87d -P m3.small.x86 -m da -O ubuntu_20_04 -H create-device-dev-cdata --customdata '{"testDate":"fromCli"}'
+--------------------------------------+-------------------------+------------------+--------+-------------------------------+
|                  ID                  |        HOSTNAME         |        OS        | STATE  |            CREATED            |
+--------------------------------------+-------------------------+------------------+--------+-------------------------------+
| 8dc6920e-cf5a-4852-994d-a53094fe9673 | create-device-dev-cdata | Ubuntu 20.04 LTS | queued | 2023-08-24 10:28:29 +0000 UTC |
+--------------------------------------+-------------------------+------------------+--------+-------------------------------+
Vasubabus-MacBook-Pro:bin vasubabu$ ./metal device create -p c309ce2c-160d-47e2-bb26-9debeb0be87d -P m3.small.x86 -m da -O ubuntu_20_04 -H create-dev-cdata --customdata '{"testDate":""}'
+--------------------------------------+------------------+------------------+--------+-------------------------------+
|                  ID                  |     HOSTNAME     |        OS        | STATE  |            CREATED            |
+--------------------------------------+------------------+------------------+--------+-------------------------------+
| a45f8746-f3b5-4fc5-8fe6-b4fa6493d365 | create-dev-cdata | Ubuntu 20.04 LTS | queued | 2023-08-24 10:40:50 +0000 UTC |
+--------------------------------------+------------------+------------------+--------+-------------------------------+
```

```
Vasubabus-MacBook-Pro:bin vasubabu$ ./metal device create -p c309ce2c-160d-47e2-bb26-9debeb0be87d --hostname netboot-custom-ipxe-1 --plan c3.small.x86 --metro sv --operating-system custom_ipxe --userdata='#!ipxe
chain -ar https://boot.netboot.xyz' --always-pxe=true
+--------------------------------------+-----------------------+-------------+--------+-------------------------------+
|                  ID                  |       HOSTNAME        |     OS      | STATE  |            CREATED            |
+--------------------------------------+-----------------------+-------------+--------+-------------------------------+
| b149fc32-bcfd-44c8-9c0e-9e5d49d382e0 | netboot-custom-ipxe-1 | Custom iPXE | queued | 2023-08-24 10:48:33 +0000 UTC |
+--------------------------------------+-----------------------+-------------+--------+-------------------------------+

<img width="1430" alt="image" src="https://github.com/equinix/metal-cli/assets/3358152/ea4d5a5a-b495-40e7-a7ec-e3a6905ac5c7">

```

```
Vasubabus-MacBook-Pro:bin vasubabu$ ./metal device create -p c309ce2c-160d-47e2-bb26-9debeb0be87d --hostname netboot-custom-ipxe --plan c3.small.x86 --metro sv --operating-system custom_ipxe --userdata='#!ipxe
> chain -ar https://boot.netboot.xyz'
+--------------------------------------+---------------------+-------------+--------+-------------------------------+
|                  ID                  |      HOSTNAME       |     OS      | STATE  |            CREATED            |
+--------------------------------------+---------------------+-------------+--------+-------------------------------+
| 4aa8977b-259b-4684-a3b4-9ff49e96db47 | netboot-custom-ipxe | Custom iPXE | queued | 2023-08-24 10:44:02 +0000 UTC |
+--------------------------------------+---------------------+-------------+--------+-------------------------------+

<img width="1416" alt="image" src="https://github.com/equinix/metal-cli/assets/3358152/a9ff3f36-4716-4cbd-a9be-cc2dc8e672b7">

```


