### PR TITLE
Updated metal-go client for sub-command orgs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/equinix/metal-cli
 go 1.19
 
 require (
-	github.com/equinix-labs/metal-go v0.11.0
+	github.com/equinix-labs/metal-go v0.12.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/packethost/packngo v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/equinix-labs/metal-go v0.11.0 h1:56gFeGZr4baJ0zRJspYWT+TY6Jjfxag4kQ1S3m6dIo8=
-github.com/equinix-labs/metal-go v0.11.0/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
+github.com/equinix-labs/metal-go v0.12.0 h1:zT+Sjham0mDY0y0B26+5i0xVaY707WmshWCzdTLF74Q=
+github.com/equinix-labs/metal-go v0.12.0/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=

--- a/internal/organizations/delete.go
+++ b/internal/organizations/delete.go
@@ -21,6 +21,7 @@
 package organizations
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/manifoldco/promptui"
@@ -33,7 +34,7 @@ func (c *Client) Delete() *cobra.Command {
 		force          bool
 	)
 	deleteOrganization := func(id string) error {
-		_, err := c.Service.Delete(id)
+		_, err := c.Service.DeleteOrganization(context.Background(), id).Execute()
 		if err != nil {
 			return err
 		}

--- a/internal/organizations/organization.go
+++ b/internal/organizations/organization.go
@@ -21,14 +21,14 @@
 package organizations
 
 import (
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/equinix/metal-cli/internal/outputs"
-	"github.com/packethost/packngo"
 	"github.com/spf13/cobra"
 )
 
 type Client struct {
 	Servicer Servicer
-	Service  packngo.OrganizationService
+	Service  metal.OrganizationsApiService
 	Out      outputs.Outputer
 }
 
@@ -45,7 +45,7 @@ func (c *Client) NewCommand() *cobra.Command {
 					root.PersistentPreRun(cmd, args)
 				}
 			}
-			c.Service = c.Servicer.API(cmd).Organizations
+			c.Service = *c.Servicer.MetalAPI(cmd).OrganizationsApi
 		},
 	}
 
@@ -60,9 +60,11 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API(*cobra.Command) *packngo.Client
-	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
+	MetalAPI(*cobra.Command) *metal.APIClient
 	Format() outputs.Format
+	Filters() map[string]string
+	Includes(defaultIncludes []string) (incl []string)
+	Excludes(defaultExcludes []string) (excl []string)
 }
 
 func NewClient(s Servicer, out outputs.Outputer) *Client {

--- a/internal/organizations/payment.go
+++ b/internal/organizations/payment.go
@@ -21,6 +21,7 @@
 package organizations
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -39,15 +40,16 @@ func (c *Client) PaymentMethods() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			paymentMethods, _, err := c.Service.ListPaymentMethods(organizationID)
-			if err != nil {
-				return fmt.Errorf("Could not list Payment Methods: %w", err)
-			}
 
+			paymentMethodsList, _, err := c.Service.FindOrganizationPaymentMethods(context.Background(), organizationID).Include(c.Servicer.Includes(nil)).Exclude(c.Servicer.Excludes(nil)).Execute()
+			if err != nil {
+				return fmt.Errorf("could not list Payment Methods: %w", err)
+			}
+			paymentMethods := paymentMethodsList.GetPaymentMethods()
 			data := make([][]string, len(paymentMethods))
 
 			for i, p := range paymentMethods {
-				data[i] = []string{p.ID, p.CardholderName, p.ExpMonth, p.ExpYear, p.Created}
+				data[i] = []string{p.GetId(), p.GetCardholderName(), p.GetExpirationMonth(), p.GetExpirationYear(), p.GetCreatedAt().String()}
 			}
 			header := []string{"ID", "Cardholder", "Exp. Month", "Exp. Year", "Created"}
 

--- a/internal/organizations/update.go
+++ b/internal/organizations/update.go
@@ -21,9 +21,10 @@
 package organizations
 
 import (
+	"context"
 	"fmt"
 
-	"github.com/packethost/packngo"
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +40,7 @@ func (c *Client) Update() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			req := &packngo.OrganizationUpdateRequest{}
+			req := metal.NewOrganizationInput()
 
 			if name != "" {
 				req.Name = &name
@@ -57,14 +58,18 @@ func (c *Client) Update() *cobra.Command {
 				req.Logo = &logo
 			}
 
-			org, _, err := c.Service.Update(organizationID, req)
+			if website != "" {
+				req.Website = &website
+			}
+
+			org, _, err := c.Service.UpdateOrganization(context.Background(), organizationID).OrganizationInput(*req).Execute()
 			if err != nil {
 				return fmt.Errorf("Could not update Organization: %w", err)
 			}
 
 			data := make([][]string, 1)
 
-			data[0] = []string{org.ID, org.Name, org.Created}
+			data[0] = []string{org.GetId(), org.GetName(), org.GetCreatedAt().String()}
 			header := []string{"ID", "Name", "Created"}
 
 			return c.Out.Output(org, header, &data)

--- a/internal/pagination/pager.go
+++ b/internal/pagination/pager.go
@@ -108,3 +108,22 @@ func GetAllEvents(s metal.EventsApiService, include []string, exclude []string) 
 		return events, nil
 	}
 }
+
+func GetAllOrganizations(s metal.OrganizationsApiService, include, exclude []string, withOutProjects string) ([]metal.Organization, error) {
+	var orgs []metal.Organization
+	page := int32(1)     // int32 | Page to return (optional) (default to 1)
+	perPage := int32(56) // int32 | Items returned per page (optional) (default to 10)
+
+	for {
+		orgPage, _, err := s.FindOrganizations(context.Background()).Include(include).Exclude(exclude).WithoutProjects(withOutProjects).Page(page).PerPage(perPage).Execute()
+		if err != nil {
+			return nil, err
+		}
+		orgs = append(orgs, orgPage.GetOrganizations()...)
+		if orgPage.Meta.GetLastPage() > orgPage.Meta.GetCurrentPage() {
+			page = page + 1
+			continue
+		}
+		return orgs, nil
+	}
+}

--- a/test/e2e/organization_test.go
+++ b/test/e2e/organization_test.go
@@ -1,0 +1,51 @@
+package e2e
+
+import (
+	"testing"
+
+	root "github.com/equinix/metal-cli/internal/cli"
+	"github.com/equinix/metal-cli/internal/organizations"
+	outputPkg "github.com/equinix/metal-cli/internal/outputs"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCli_Organization(t *testing.T) {
+	subCommand := "organization"
+	consumerToken := ""
+	apiURL := ""
+	Version := "metal"
+	rootClient := root.NewClient(consumerToken, apiURL, Version)
+	type fields struct {
+		MainCmd  *cobra.Command
+		Outputer outputPkg.Outputer
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    *cobra.Command
+		cmdFunc func(*testing.T, *cobra.Command)
+	}{
+		{
+			name: "get",
+			fields: fields{
+				MainCmd:  organizations.NewClient(rootClient, outputPkg.Outputer(&outputPkg.Standard{})).NewCommand(),
+				Outputer: outputPkg.Outputer(&outputPkg.Standard{}),
+			},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				root.SetArgs([]string{subCommand, "get"})
+				err := root.Execute()
+				assert.NoError(t, err)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd := rootClient.NewCommand()
+			rootCmd.AddCommand(tt.fields.MainCmd)
+			tt.cmdFunc(t, tt.fields.MainCmd)
+		})
+	}
+}


### PR DESCRIPTION
Breakout from https://github.com/equinix/metal-cli/pull/270

What this PR does / why we need it:

This PR replaces packngo with metal-go for all interactions with the Equinix Metal API specifically for orgs sub commands

DISCUSSION POINTS: