### PR TITLE
Updated metal-go client for sub-command events

### DIFF
--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -21,17 +21,17 @@
 package events
 
 import (
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/equinix/metal-cli/internal/outputs"
-	"github.com/packethost/packngo"
 	"github.com/spf13/cobra"
 )
 
 type Client struct {
 	Servicer            Servicer
-	EventService        packngo.EventService
-	DeviceService       packngo.DeviceService
-	ProjectService      packngo.ProjectService
-	OrganizationService packngo.OrganizationService
+	EventService        metal.EventsApiService
+	DeviceService       metal.DevicesApiService
+	ProjectService      metal.ProjectsApiService
+	OrganizationService metal.OrganizationsApiService
 
 	Out outputs.Outputer
 }
@@ -48,10 +48,10 @@ func (c *Client) NewCommand() *cobra.Command {
 					root.PersistentPreRun(cmd, args)
 				}
 			}
-			c.EventService = c.Servicer.API(cmd).Events
-			c.DeviceService = c.Servicer.API(cmd).Devices
-			c.ProjectService = c.Servicer.API(cmd).Projects
-			c.OrganizationService = c.Servicer.API(cmd).Organizations
+			c.EventService = *c.Servicer.MetalAPI(cmd).EventsApi
+			c.DeviceService = *c.Servicer.MetalAPI(cmd).DevicesApi
+			c.ProjectService = *c.Servicer.MetalAPI(cmd).ProjectsApi
+			c.OrganizationService = *c.Servicer.MetalAPI(cmd).OrganizationsApi
 		},
 	}
 
@@ -62,8 +62,7 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API(*cobra.Command) *packngo.Client
-	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
+	MetalAPI(*cobra.Command) *metal.APIClient
 	Format() outputs.Format
 }
 

--- a/internal/pagination/pager.go
+++ b/internal/pagination/pager.go
@@ -24,3 +24,87 @@ func GetAllProjects(s metal.ProjectsApiService, include []string, exclude []stri
 		return projects, nil
 	}
 }
+
+func GetDeviceEvents(s metal.EventsApiService, deviceId string, include []string, exclude []string) ([]metal.Event, error) {
+	var events []metal.Event
+
+	page := int32(1)     // int32 | Page to return (optional) (default to 1)
+	perPage := int32(20) // int32 | Items returned per page (optional) (default to 10)
+
+	for {
+		eventsPage, _, err := s.FindDeviceEvents(context.Background(), deviceId).Include(include).Exclude(exclude).Page(page).PerPage(perPage).Execute()
+		if err != nil {
+			return nil, err
+		}
+
+		events = append(events, eventsPage.GetEvents()...)
+		if eventsPage.Meta.GetLastPage() > eventsPage.Meta.GetCurrentPage() {
+			page = page + 1
+			continue
+		}
+		return events, nil
+	}
+}
+
+func GetProjectEvents(s metal.EventsApiService, projectId string, include []string, exclude []string) ([]metal.Event, error) {
+	var events []metal.Event
+
+	page := int32(1)     // int32 | Page to return (optional) (default to 1)
+	perPage := int32(20) // int32 | Items returned per page (optional) (default to 10)
+
+	for {
+		eventsPage, _, err := s.FindProjectEvents(context.Background(), projectId).Include(include).Exclude(exclude).Page(page).PerPage(perPage).Execute()
+		if err != nil {
+			return nil, err
+		}
+
+		events = append(events, eventsPage.GetEvents()...)
+		if eventsPage.Meta.GetLastPage() > eventsPage.Meta.GetCurrentPage() {
+			page = page + 1
+			continue
+		}
+		return events, nil
+	}
+}
+
+func GetOrganizationEvents(s metal.EventsApiService, orgId string, include []string, exclude []string) ([]metal.Event, error) {
+	var events []metal.Event
+
+	page := int32(1)     // int32 | Page to return (optional) (default to 1)
+	perPage := int32(20) // int32 | Items returned per page (optional) (default to 10)
+
+	for {
+		eventsPage, _, err := s.FindOrganizationEvents(context.Background(), orgId).Include(include).Exclude(exclude).Page(page).PerPage(perPage).Execute()
+		if err != nil {
+			return nil, err
+		}
+
+		events = append(events, eventsPage.GetEvents()...)
+		if eventsPage.Meta.GetLastPage() > eventsPage.Meta.GetCurrentPage() {
+			page = page + 1
+			continue
+		}
+		return events, nil
+	}
+}
+
+func GetAllEvents(s metal.EventsApiService, include []string, exclude []string) ([]metal.Event, error) {
+	var events []metal.Event
+
+	page := int32(1)     // int32 | Page to return (optional) (default to 1)
+	perPage := int32(20) // int32 | Items returned per page (optional) (default to 10)
+
+	for {
+		eventsPage, _, err := s.FindEvents(context.Background()).Include(include).Exclude(exclude).Page(page).PerPage(perPage).Execute()
+		if err != nil {
+			return nil, err
+		}
+
+		events = append(events, eventsPage.GetEvents()...)
+		if eventsPage.Meta.GetLastPage() > eventsPage.Meta.GetCurrentPage() {
+			page = page + 1
+			continue
+		}
+		return events, nil
+	}
+}


### PR DESCRIPTION
Breakout from https://github.com/equinix/metal-cli/pull/270

What this PR does / why we need it:

This PR replaces packngo with metal-go for all interactions with the Equinix Metal API specifically for Events sub commands

DISCUSSION POINTS: