### PR TITLE
Updated metal-go client for sub-commands ports

### DIFF
--- a/internal/ports/port.go
+++ b/internal/ports/port.go
@@ -21,15 +21,15 @@
 package ports
 
 import (
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/equinix/metal-cli/internal/outputs"
-	"github.com/packethost/packngo"
 	"github.com/spf13/cobra"
 )
 
 type Client struct {
 	Servicer    Servicer
-	PortService packngo.PortService
-	VLANService packngo.VLANAssignmentService
+	PortService metal.PortsApiService
+	VLANService metal.VLANsApiService
 	Out         outputs.Outputer
 }
 
@@ -45,8 +45,8 @@ func (c *Client) NewCommand() *cobra.Command {
 					root.PersistentPreRun(cmd, args)
 				}
 			}
-			c.PortService = c.Servicer.API(cmd).Ports
-			c.VLANService = c.Servicer.API(cmd).VLANAssignments
+			c.PortService = *c.Servicer.MetalAPI(cmd).PortsApi
+			c.VLANService = *c.Servicer.MetalAPI(cmd).VLANsApi
 		},
 	}
 
@@ -59,8 +59,7 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API(*cobra.Command) *packngo.Client
-	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
+	MetalAPI(*cobra.Command) *metal.APIClient
 }
 
 func NewClient(s Servicer, out outputs.Outputer) *Client {

--- a/internal/ports/retrieve.go
+++ b/internal/ports/retrieve.go
@@ -21,10 +21,10 @@
 package ports
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
-	"github.com/packethost/packngo"
 	"github.com/spf13/cobra"
 )
 
@@ -41,17 +41,17 @@ func (c *Client) Retrieve() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			listOpts := c.Servicer.ListOptions(nil, nil)
+			inc := []string{}
+			exc := []string{}
 
-			getOpts := &packngo.GetOptions{Includes: listOpts.Includes, Excludes: listOpts.Excludes}
-			port, _, err := c.PortService.Get(portID, getOpts)
+			port, _, err := c.PortService.FindPortById(context.Background(), portID).Include(inc).Exclude(exc).Execute()
 			if err != nil {
 				return fmt.Errorf("Could not get Port: %w", err)
 			}
 
 			data := make([][]string, 1)
 
-			data[0] = []string{port.ID, port.Name, port.Type, port.NetworkType, port.Data.MAC, strconv.FormatBool(port.Data.Bonded)}
+			data[0] = []string{port.GetId(), port.GetName(), port.GetType(), port.GetNetworkType(), port.Data.GetMac(), strconv.FormatBool(port.Data.GetBonded())}
 			header := []string{"ID", "Name", "Type", "Network Type", "MAC", "Bonded"}
 
 			return c.Out.Output(port, header, &data)


### PR DESCRIPTION
Breakout from https://github.com/equinix/metal-cli/pull/270

What this PR does / why we need it:

This PR replaces packngo with metal-go for all interactions with the Equinix Metal API specifically for ports sub commands

DISCUSSION POINTS:


Missing Includes and Excludes in Spec for the API "CreatePortVlanAssignmentBatch"