### PR TITLE
Added support for --include, --exclude, and --filter command-line flags

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -264,6 +264,77 @@ func (c *Client) NewCommand() *cobra.Command {
 	return c.rootCmd
 }
 
+func (c *Client) Includes(defaultIncludes []string) (incl []string) {
+	var inc []string
+
+	inc = defaultIncludes
+
+	if c.rootCmd.Flags().Changed("include") {
+		inc = *c.includes
+	}
+
+	return inc
+}
+
+func (c *Client) Excludes(defaultExcludes []string) (excl []string) {
+	var exc []string
+
+	exc = defaultExcludes
+
+	if c.rootCmd.Flags().Changed("exclude") {
+		exc = *c.excludes
+	}
+
+	return exc
+}
+
+func (c *Client) Search() (sea string) {
+	var search string
+
+	if c.rootCmd.Flags().Changed("search") {
+		search = c.search
+	}
+
+	return search
+}
+
+func (c *Client) SortBy() (sBy string) {
+
+	var sortBy string
+
+	if c.rootCmd.Flags().Changed("sort-by") {
+		sortBy = c.sortBy
+	}
+
+	return sortBy
+}
+
+func (c *Client) SortDirection() (sDir string) {
+	var sortDir string
+
+	if c.rootCmd.Flags().Changed("sort-dir") {
+		sortDir = c.sortDir
+	}
+
+	return sortDir
+}
+
+func (c *Client) Filters() map[string]string {
+	mapFilt := make(map[string]string)
+	if c.rootCmd.Flags().Changed("filter") {
+		for _, kv := range *c.filters {
+			var k, v string
+			tokens := strings.SplitN(kv, "=", 2)
+			k = strings.TrimSpace(tokens[0])
+			if len(tokens) != 1 {
+				v = strings.TrimSpace(tokens[1])
+			}
+			mapFilt[k] = v
+		}
+	}
+	return mapFilt
+}
+
 // ListOptions creates a packngo.ListOptions using the includes and excludes persistent
 // flags. When not defined, the defaults given will be supplied.
 func (c *Client) ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions {

--- a/internal/plans/plan.go
+++ b/internal/plans/plan.go
@@ -56,6 +56,9 @@ func (c *Client) NewCommand() *cobra.Command {
 
 type Servicer interface {
 	MetalAPI(*cobra.Command) *metal.APIClient
+	Filters() map[string]string
+	Includes(defaultIncludes []string) (incl []string)
+	Excludes(defaultExcludes []string) (excl []string)
 }
 
 func NewClient(s Servicer, out outputs.Outputer) *Client {

--- a/internal/plans/retrieve.go
+++ b/internal/plans/retrieve.go
@@ -38,10 +38,23 @@ func (c *Client) Retrieve() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			plansList, _, err := c.Service.FindPlans(context.Background()).Execute()
+
+			request := c.Service.FindPlans(context.Background()).Include(c.Servicer.Includes(nil)).Exclude(c.Servicer.Excludes(nil))
+			filters := c.Servicer.Filters()
+
+			if filters["type"] != "" {
+				request = request.Type_(filters["type"])
+			}
+
+			if filters["slug"] != "" {
+				request = request.Slug(filters["slug"])
+			}
+
+			plansList, _, err := request.Execute()
 			if err != nil {
 				return fmt.Errorf("could not list plans: %w", err)
 			}
+
 			plans := plansList.GetPlans()
 			data := make([][]string, len(plans))
 


### PR DESCRIPTION
This PR fixes the issue https://github.com/equinix/metal-cli/issues/292

Test Results:
================
# --filter && --include
## Cmd: metal plans get --filter slug=m3.small.x86 --include available_in

* Packngo:
```
vasu@vasu-cloud:~/Equinix/metal-cli/bin$ ./metal plans get --filter slug=m3.small.x86 --include available_in 
+--------------------------------------+--------------+--------------+
|                  ID                  |     SLUG     |     NAME     |
+--------------------------------------+--------------+--------------+
| b1c73160-4240-5a4d-a0ae-e61687a00db1 | m3.small.x86 | m3.small.x86 |
+--------------------------------------+--------------+--------------+
```
* Metal-Go
```
vasu@vasu-cloud:~/Equinix/metal-cli$ metal plans get --filter slug=m3.small.x86 --include available_in
+--------------------------------------+--------------+--------------+
|                  ID                  |     SLUG     |     NAME     |
+--------------------------------------+--------------+--------------+
| b1c73160-4240-5a4d-a0ae-e61687a00db1 | m3.small.x86 | m3.small.x86 |
+--------------------------------------+--------------+--------------+
```
# --include
## Cmd: metal plans get --include available_in
* Packngo:
```
vasu@vasu-cloud:~/Equinix/metal-cli$ metal plans get --include available_in
+--------------------------------------+-----------------------------+-------------------------------------+
|                  ID                  |            SLUG             |                NAME                 |
+--------------------------------------+-----------------------------+-------------------------------------+
| 60c3dcae-4430-587d-a786-dbc797a7d1c2 | a3.large.opt-s4a1           | a3.large.opt-s4a1.x86               |
| f366368c-6b7c-5137-a476-cd6d4a74565a | a3.large.opt-s4a5n1.x86     | a3.large.opt-s4a5n1.x86             |
| de91fd9e-55fc-5741-b8cb-68dfcc703670 | a3.large.opt-s5a1           | a3.large.opt-s5a1.x86               |
| 0798abd8-f69c-5841-9e68-badfb5f9d9a8 | a3.large.opt-s6a1           | a3.large.opt-s6a1.x86               |
| 22a903bb-0c29-51be-b9a4-50c31ca04a33 | a3.large.x86                | a3.large.x86                        |
| d16a68ff-b21c-4781-a22b-3a0f37c435f8 | c2.large.arm                | c2.large.arm                        |
| 5aeee4f9-1137-4514-8f3e-a1e103b02966 | c2.medium.x86               | c2.medium.x86                       |
| 6aeca179-0d54-5e3f-88ed-41f96d5bc55d | c3.large.arm64              | c3.large.arm64                      |
| 9a9f4a04-aaf5-52d5-958d-14582cf1a94c | c3.medium.opt-c1            | c3.medium.opt-c1.x86                |
| 69ab6b9f-4c9e-56d6-b94b-9f20c37a3b33 | c3.medium.opt-c1m1          | c3.medium.opt-c1m1.x86              |
| 359ba4aa-6353-4480-bce2-a6dcd5a69aaa | c3.medium.x86               | c3.medium.x86                       |
| 18e285e0-1872-11ea-8d71-362b9e155667 | c3.small.x86                | c3.small.x86                        |
| edd8a672-9e5c-46ea-b110-ca0ae9711e9c | f3.large.x86                | f3.large.x86                        |
| 3ef12e7c-4fe2-4686-981d-86383f7e61af | f3.medium.x86               | f3.medium.x86                       |
| 18810cec-1711-4f30-b323-a1001804b10f | g2.large.x86                | g2.large.x86                        |
| c5a9c64a-07e4-46a9-8dfe-2437f521dcb8 | m2.xlarge.x86               | m2.xlarge.x86                       |
| 0e87da46-c620-55a6-822f-4e690abe5891 | m3.large.opt-c2m3s3         | m3.large.opt-c2m3s3.x86             |
| 0352ed7d-6a31-56f4-a1b9-3dce38745d1e | m3.large.opt-c2s1           | m3.large.opt-c2s1.x86               |
| cb6a01ea-0120-4a59-ad6a-bcc14d8bf487 | m3.large.x86                | m3.large.x86                        |
| daabfc72-8373-51c7-a0c7-b33ff38fd61f | m3.small.opt-m1             | m3.small.opt-m1.x86                 |
| b1c73160-4240-5a4d-a0ae-e61687a00db1 | m3.small.x86                | m3.small.x86                        |
| 174c4bec-7090-4651-9b81-567080a4a7cb | n2.xlarge.x86               | n2.xlarge.x86                       |
| 4c45d940-d404-5bb0-a489-0cd17c3c3d28 | n3.xlarge.opt-m4            | n3.xlarge.opt-m4.x86                |
| 6c7f4118-35cd-59fa-b92a-07d438e5de85 | n3.xlarge.opt-m4s2.x86      | n3.xlarge.opt-m4s2.x86              |
| 69a7dd05-7b54-5739-810e-f74265c1e302 | n3.xlarge.x86               | n3.xlarge.x86                       |
| 212c1a40-6007-4eba-bba6-3c587648ad10 | pure.capacity.200           | Pure Storage - Pure Capacity 200    |
| 94f9d34e-0023-4d24-a912-21edd671d28c | pure.capacity.500           | Pure Storage - Pure Capacity 500    |
| daae3e29-86d4-4399-81a8-5b2fac7e7a4f | pure.performance.100        | Pure Storage - Pure Performance 100 |
| 72f68dce-5e7c-4463-837b-df13860c1bab | pure.performance.50         | Pure Storage - Pure Performance 50  |
| e645c9a0-2156-47e7-b42e-39d0ccb52022 | s3.xlarge.x86               | s3.xlarge.x86                       |
| d249fd31-0af2-4318-8393-1b130beadde7 | storage.custom              | Custom Storage Appliance            |
| 1cf2d27c-d1f7-417b-999e-519693b2f269 | storage.dell                | Dell Storage Appliance              |
| b391b934-d3d7-4532-b70b-346b0ac0494c | t3.small.x86                | t3.small.x86                        |
| a4925a58-ab27-40ac-8736-d0e36650956e | w3amd.7402p.256.8160        | w3amd.7402p.256.8160.x86            |
| a804c85c-17e8-5464-b5e5-4f1773ca2c38 | w3amd.7502p.1024.15840      | w3amd.7502p.1024.15840.x86          |
| a1764ba8-5009-5df6-b359-ec250a010b6f | w3amd.7502p.256.4320        | w3amd.7502p.256.4320.x86            |
| 79c4643a-b1ae-5dfe-9b3d-d8beaca8fc67 | w3amd.75xx24c.256.4320      | w3amd.75xx24c.256.4320.x86          |
| 0b9e0835-cd05-472e-8b83-fe1d25175096 | w3amd.75xx24c.256.8160      | w3amd.75xx24c.256.8160.x86          |
| 5a462c78-b1ad-4f37-8ac6-3b0e6ebe68c6 | w3amd.75xx24c.512.8160      | w3amd.75xx24c.512.8160.x86          |
| d7ab303a-b606-5959-bbbd-dafe52e3dfa3 | w3intel.6354.128.116160     | w3intel.6354.128.116160.x86         |
| c3ee2482-060c-4d17-949f-377ee3c18b08 | x2.xlarge.x86               | x2.xlarge.x86                       |
| 797d8dee-dc7e-46be-a57c-b0ea5990fb77 | x3.xlarge.x86               | x3.xlarge.x86                       |
| 0acedb10-dc6f-4a58-977d-cbb5e12929fa | x.large.arm                 | x.large.arm                         |
| 07826054-824d-4db4-a486-fb5c6ba4bacd | x.small.x86                 | x.small.x86                         |
| 60c3dcae-4430-587d-a786-dbc797a7d1c2 | a3.large.opt-s4a1.x86       | a3.large.opt-s4a1.x86               |
| de91fd9e-55fc-5741-b8cb-68dfcc703670 | a3.large.opt-s5a1.x86       | a3.large.opt-s5a1.x86               |
| 0798abd8-f69c-5841-9e68-badfb5f9d9a8 | a3.large.opt-s6a1.x86       | a3.large.opt-s6a1.x86               |
| 9a9f4a04-aaf5-52d5-958d-14582cf1a94c | c3.medium.opt-c1.x86        | c3.medium.opt-c1.x86                |
| 69ab6b9f-4c9e-56d6-b94b-9f20c37a3b33 | c3.medium.opt-c1m1.x86      | c3.medium.opt-c1m1.x86              |
| 0e87da46-c620-55a6-822f-4e690abe5891 | m3.large.opt-c2m3s3.x86     | m3.large.opt-c2m3s3.x86             |
| 0352ed7d-6a31-56f4-a1b9-3dce38745d1e | m3.large.opt-c2s1.x86       | m3.large.opt-c2s1.x86               |
| daabfc72-8373-51c7-a0c7-b33ff38fd61f | m3.small.opt-m1.x86         | m3.small.opt-m1.x86                 |
| 4c45d940-d404-5bb0-a489-0cd17c3c3d28 | n3.xlarge.opt-m4.x86        | n3.xlarge.opt-m4.x86                |
| a4925a58-ab27-40ac-8736-d0e36650956e | w3amd.7402p.256.8160.x86    | w3amd.7402p.256.8160.x86            |
| a804c85c-17e8-5464-b5e5-4f1773ca2c38 | w3amd.7502p.1024.15840.x86  | w3amd.7502p.1024.15840.x86          |
| a1764ba8-5009-5df6-b359-ec250a010b6f | w3amd.7502p.256.4320.x86    | w3amd.7502p.256.4320.x86            |
| 79c4643a-b1ae-5dfe-9b3d-d8beaca8fc67 | w3amd.75xx24c.256.4320.x86  | w3amd.75xx24c.256.4320.x86          |
| 0b9e0835-cd05-472e-8b83-fe1d25175096 | w3amd.75xx24c.256.8160.x86  | w3amd.75xx24c.256.8160.x86          |
| d7ab303a-b606-5959-bbbd-dafe52e3dfa3 | w3intel.6354.128.116160.x86 | w3intel.6354.128.116160.x86         |
+--------------------------------------+-----------------------------+-------------------------------------+
```
* Metal-Go
```
vasu@vasu-cloud:~/Equinix/metal-cli/bin$ ./metal plans get --include available_in 
+--------------------------------------+-----------------------------+-------------------------------------+
|                  ID                  |            SLUG             |                NAME                 |
+--------------------------------------+-----------------------------+-------------------------------------+
| 60c3dcae-4430-587d-a786-dbc797a7d1c2 | a3.large.opt-s4a1           | a3.large.opt-s4a1.x86               |
| f366368c-6b7c-5137-a476-cd6d4a74565a | a3.large.opt-s4a5n1.x86     | a3.large.opt-s4a5n1.x86             |
| de91fd9e-55fc-5741-b8cb-68dfcc703670 | a3.large.opt-s5a1           | a3.large.opt-s5a1.x86               |
| 0798abd8-f69c-5841-9e68-badfb5f9d9a8 | a3.large.opt-s6a1           | a3.large.opt-s6a1.x86               |
| 22a903bb-0c29-51be-b9a4-50c31ca04a33 | a3.large.x86                | a3.large.x86                        |
| d16a68ff-b21c-4781-a22b-3a0f37c435f8 | c2.large.arm                | c2.large.arm                        |
| 5aeee4f9-1137-4514-8f3e-a1e103b02966 | c2.medium.x86               | c2.medium.x86                       |
| 6aeca179-0d54-5e3f-88ed-41f96d5bc55d | c3.large.arm64              | c3.large.arm64                      |
| 9a9f4a04-aaf5-52d5-958d-14582cf1a94c | c3.medium.opt-c1            | c3.medium.opt-c1.x86                |
| 69ab6b9f-4c9e-56d6-b94b-9f20c37a3b33 | c3.medium.opt-c1m1          | c3.medium.opt-c1m1.x86              |
| 359ba4aa-6353-4480-bce2-a6dcd5a69aaa | c3.medium.x86               | c3.medium.x86                       |
| 18e285e0-1872-11ea-8d71-362b9e155667 | c3.small.x86                | c3.small.x86                        |
| edd8a672-9e5c-46ea-b110-ca0ae9711e9c | f3.large.x86                | f3.large.x86                        |
| 3ef12e7c-4fe2-4686-981d-86383f7e61af | f3.medium.x86               | f3.medium.x86                       |
| 18810cec-1711-4f30-b323-a1001804b10f | g2.large.x86                | g2.large.x86                        |
| c5a9c64a-07e4-46a9-8dfe-2437f521dcb8 | m2.xlarge.x86               | m2.xlarge.x86                       |
| 0e87da46-c620-55a6-822f-4e690abe5891 | m3.large.opt-c2m3s3         | m3.large.opt-c2m3s3.x86             |
| 0352ed7d-6a31-56f4-a1b9-3dce38745d1e | m3.large.opt-c2s1           | m3.large.opt-c2s1.x86               |
| cb6a01ea-0120-4a59-ad6a-bcc14d8bf487 | m3.large.x86                | m3.large.x86                        |
| daabfc72-8373-51c7-a0c7-b33ff38fd61f | m3.small.opt-m1             | m3.small.opt-m1.x86                 |
| b1c73160-4240-5a4d-a0ae-e61687a00db1 | m3.small.x86                | m3.small.x86                        |
| 174c4bec-7090-4651-9b81-567080a4a7cb | n2.xlarge.x86               | n2.xlarge.x86                       |
| 4c45d940-d404-5bb0-a489-0cd17c3c3d28 | n3.xlarge.opt-m4            | n3.xlarge.opt-m4.x86                |
| 6c7f4118-35cd-59fa-b92a-07d438e5de85 | n3.xlarge.opt-m4s2.x86      | n3.xlarge.opt-m4s2.x86              |
| 69a7dd05-7b54-5739-810e-f74265c1e302 | n3.xlarge.x86               | n3.xlarge.x86                       |
| 212c1a40-6007-4eba-bba6-3c587648ad10 | pure.capacity.200           | Pure Storage - Pure Capacity 200    |
| 94f9d34e-0023-4d24-a912-21edd671d28c | pure.capacity.500           | Pure Storage - Pure Capacity 500    |
| daae3e29-86d4-4399-81a8-5b2fac7e7a4f | pure.performance.100        | Pure Storage - Pure Performance 100 |
| 72f68dce-5e7c-4463-837b-df13860c1bab | pure.performance.50         | Pure Storage - Pure Performance 50  |
| e645c9a0-2156-47e7-b42e-39d0ccb52022 | s3.xlarge.x86               | s3.xlarge.x86                       |
| d249fd31-0af2-4318-8393-1b130beadde7 | storage.custom              | Custom Storage Appliance            |
| 1cf2d27c-d1f7-417b-999e-519693b2f269 | storage.dell                | Dell Storage Appliance              |
| b391b934-d3d7-4532-b70b-346b0ac0494c | t3.small.x86                | t3.small.x86                        |
| a4925a58-ab27-40ac-8736-d0e36650956e | w3amd.7402p.256.8160        | w3amd.7402p.256.8160.x86            |
| a804c85c-17e8-5464-b5e5-4f1773ca2c38 | w3amd.7502p.1024.15840      | w3amd.7502p.1024.15840.x86          |
| a1764ba8-5009-5df6-b359-ec250a010b6f | w3amd.7502p.256.4320        | w3amd.7502p.256.4320.x86            |
| 79c4643a-b1ae-5dfe-9b3d-d8beaca8fc67 | w3amd.75xx24c.256.4320      | w3amd.75xx24c.256.4320.x86          |
| 0b9e0835-cd05-472e-8b83-fe1d25175096 | w3amd.75xx24c.256.8160      | w3amd.75xx24c.256.8160.x86          |
| 5a462c78-b1ad-4f37-8ac6-3b0e6ebe68c6 | w3amd.75xx24c.512.8160      | w3amd.75xx24c.512.8160.x86          |
| d7ab303a-b606-5959-bbbd-dafe52e3dfa3 | w3intel.6354.128.116160     | w3intel.6354.128.116160.x86         |
| c3ee2482-060c-4d17-949f-377ee3c18b08 | x2.xlarge.x86               | x2.xlarge.x86                       |
| 797d8dee-dc7e-46be-a57c-b0ea5990fb77 | x3.xlarge.x86               | x3.xlarge.x86                       |
| 0acedb10-dc6f-4a58-977d-cbb5e12929fa | x.large.arm                 | x.large.arm                         |
| 07826054-824d-4db4-a486-fb5c6ba4bacd | x.small.x86                 | x.small.x86                         |
| 60c3dcae-4430-587d-a786-dbc797a7d1c2 | a3.large.opt-s4a1.x86       | a3.large.opt-s4a1.x86               |
| de91fd9e-55fc-5741-b8cb-68dfcc703670 | a3.large.opt-s5a1.x86       | a3.large.opt-s5a1.x86               |
| 0798abd8-f69c-5841-9e68-badfb5f9d9a8 | a3.large.opt-s6a1.x86       | a3.large.opt-s6a1.x86               |
| 9a9f4a04-aaf5-52d5-958d-14582cf1a94c | c3.medium.opt-c1.x86        | c3.medium.opt-c1.x86                |
| 69ab6b9f-4c9e-56d6-b94b-9f20c37a3b33 | c3.medium.opt-c1m1.x86      | c3.medium.opt-c1m1.x86              |
| 0e87da46-c620-55a6-822f-4e690abe5891 | m3.large.opt-c2m3s3.x86     | m3.large.opt-c2m3s3.x86             |
| 0352ed7d-6a31-56f4-a1b9-3dce38745d1e | m3.large.opt-c2s1.x86       | m3.large.opt-c2s1.x86               |
| daabfc72-8373-51c7-a0c7-b33ff38fd61f | m3.small.opt-m1.x86         | m3.small.opt-m1.x86                 |
| 4c45d940-d404-5bb0-a489-0cd17c3c3d28 | n3.xlarge.opt-m4.x86        | n3.xlarge.opt-m4.x86                |
| a4925a58-ab27-40ac-8736-d0e36650956e | w3amd.7402p.256.8160.x86    | w3amd.7402p.256.8160.x86            |
| a804c85c-17e8-5464-b5e5-4f1773ca2c38 | w3amd.7502p.1024.15840.x86  | w3amd.7502p.1024.15840.x86          |
| a1764ba8-5009-5df6-b359-ec250a010b6f | w3amd.7502p.256.4320.x86    | w3amd.7502p.256.4320.x86            |
| 79c4643a-b1ae-5dfe-9b3d-d8beaca8fc67 | w3amd.75xx24c.256.4320.x86  | w3amd.75xx24c.256.4320.x86          |
| 0b9e0835-cd05-472e-8b83-fe1d25175096 | w3amd.75xx24c.256.8160.x86  | w3amd.75xx24c.256.8160.x86          |
| d7ab303a-b606-5959-bbbd-dafe52e3dfa3 | w3intel.6354.128.116160.x86 | w3intel.6354.128.116160.x86         |
+--------------------------------------+-----------------------------+-------------------------------------+
```
# JSON Output
## Cmd: metal plans get --include available_in -o json | more
* Packngo:
```
vasu@vasu-cloud:~/Equinix/metal-cli$ metal plans get --include available_in -o json | more
[
  {
    "id": "60c3dcae-4430-587d-a786-dbc797a7d1c2",
    "slug": "a3.large.opt-s4a1",
    "name": "a3.large.opt-s4a1.x86",
    "description": "a3.large.opt-s4a1.x86",
    "line": "baremetal",
    "specs": {
      "cpus": [
        {
          "count": 2,
          "type": "Intel Xeon Gold 6338"
        }
      ],
      "memory": {
        "total": "1024GB"
      },
      "drives": [
        {
          "count": 2,
          "size": "240GB",
          "type": "SSD"
        },
        {
          "count": 6,
          "size": "7.84TB",
          "type": "SSD"
        }
      ],
      "nics": [
        {
          "count": 4,
          "type": "25Gbps"
        }
      ],
      "features": {
        "raid": true,
        "txt": true
      }
    },
    "pricing": {
      "hour": 11
    },
    "deployment_types": [],
    "class": "a3.large.opt-s4a1",
    "available_in": [],
    "available_in_metros": [],
    "reservation_pricing": {
      "one_year": null,
      "three_year": null,
      "Metros": {}
    }
  },
  {
    "id": "f366368c-6b7c-5137-a476-cd6d4a74565a",
    "slug": "a3.large.opt-s4a5n1.x86",
    "name": "a3.large.opt-s4a5n1.x86",
    "description": "a3.large.opt-s4a5n1.x86",
    "line": "baremetal",
```
*Metal-go:
```
vasu@vasu-cloud:~/Equinix/metal-cli/bin$ ./metal plans get --include available_in -o json | more
[
  {
    "available_in": [],
    "available_in_metros": [],
    "categories": [
      "compute"
    ],
    "class": "a3.large.opt-s4a1",
    "deployment_types": [],
    "description": "a3.large.opt-s4a1.x86",
    "id": "60c3dcae-4430-587d-a786-dbc797a7d1c2",
    "legacy": false,
    "line": "baremetal",
    "name": "a3.large.opt-s4a1.x86",
    "pricing": {
      "hour": 11
    },
    "reservation_pricing": {},
    "slug": "a3.large.opt-s4a1",
    "specs": {
      "cpus": [
        {
          "count": 2,
          "type": "Intel Xeon Gold 6338"
        }
      ],
      "drives": [
        {
          "category": "boot",
          "count": 2,
          "size": "240GB",
          "type": "SSD"
        },
        {
          "category": "storage",
          "count": 6,
          "size": "7.84TB",
          "type": "SSD"
        }
      ],
      "features": {
        "raid": true,
        "txt": true
      },
      "memory": {
        "total": "1024GB"
      },
      "nics": [
        {
          "count": 4,
          "type": "25Gbps"
        }
      ]
    }
  },
  {
    "available_in": [],
    "available_in_metros": [],
    "categories": [
```