### PR TITLE
ci: Update test workflow to support running end-to-end tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,9 @@ jobs:
       run: go mod download
     - name: Build
       run: go build -v ./...
-    - name: TF tests
+    - name: Unit tests
+      run: go test -v -short -cover -parallel 4 ./...
+    - name: End-to-end tests
       run: go test -v -cover -parallel 4 ./...
+      env:
+        METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}


### PR DESCRIPTION
End-to-end tests interact with the Equinix Metal API and thus require an API token.  This adds a step to the existing `test` GitHub Actions workflow that sets a `METAL_AUTH_TOKEN` environment variable that can be used by end-to-end tests.  The existing test step is updated to set the `short` flag.  The intent is that we will use the `short` flag to skip end-to-end tests as documented here:

https://pkg.go.dev/testing#hdr-Skipping