### PR TITLE
fix: always bind flags to env vars when configuring a command

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -137,8 +137,9 @@ func (c *Client) Config(cmd *cobra.Command) *viper.Viper {
 
 		v.SetEnvPrefix(envPrefix)
 		c.viper = v
-		bindFlags(cmd, v)
 	}
+
+	bindFlags(cmd, c.viper)
 
 	flagToken := cmd.Flag("token").Value.String()
 	envToken := cmd.Flag("auth-token").Value.String()


### PR DESCRIPTION
Previously the `bindFlags` function that sets command flags based on environment variables was only called the first time that the `Config` function executes for a command.

In regular use, this isn't a problem because each time a user runs a `metal` command, it's a separate execution.  However, this causes problems in end-to-end tests because only the first test of each subcommand runs the `bindFlags` function, so subsequent tests fail because they do not look up the API token in environment variables.

This moves the `bindFlags` call so that it runs every time the `Config` function runs, which enables tests to consistently set flags based on environment variables.