### PR TITLE
Updated metal-go client for sub-command SSH-KEY

### DIFF
--- a/internal/ssh/create.go
+++ b/internal/ssh/create.go
@@ -21,9 +21,10 @@
 package ssh
 
 import (
+	"context"
 	"fmt"
 
-	"github.com/packethost/packngo"
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -42,19 +43,19 @@ func (c *Client) Create() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			req := packngo.SSHKeyCreateRequest{
-				Label: label,
-				Key:   key,
+			sSHKeyCreateInput := &metal.SSHKeyCreateInput{
+				Key:   &key,
+				Label: &label,
 			}
 
-			s, _, err := c.Service.Create(&req)
+			s, _, err := c.Service.CreateSSHKey(context.Background()).SSHKeyCreateInput(*sSHKeyCreateInput).Execute()
 			if err != nil {
 				return fmt.Errorf("Could not create SSHKey: %w", err)
 			}
 
 			data := make([][]string, 1)
 
-			data[0] = []string{s.ID, s.Label, s.Created}
+			data[0] = []string{s.GetId(), s.GetLabel(), s.GetCreatedAt().String()}
 			header := []string{"ID", "Label", "Created"}
 			return c.Out.Output(s, header, &data)
 		},

--- a/internal/ssh/delete.go
+++ b/internal/ssh/delete.go
@@ -21,6 +21,7 @@
 package ssh
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/manifoldco/promptui"
@@ -33,7 +34,7 @@ func (c *Client) Delete() *cobra.Command {
 		force    bool
 	)
 	deleteSSHKey := func(id string) error {
-		_, err := c.Service.Delete(id)
+		_, err := c.Service.DeleteSSHKey(context.Background(), sshKeyID).Execute()
 		if err != nil {
 			return err
 		}

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -21,14 +21,14 @@
 package ssh
 
 import (
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/equinix/metal-cli/internal/outputs"
-	"github.com/packethost/packngo"
 	"github.com/spf13/cobra"
 )
 
 type Client struct {
 	Servicer Servicer
-	Service  packngo.SSHKeyService
+	Service  metal.SSHKeysApiService
 	Out      outputs.Outputer
 }
 
@@ -45,7 +45,7 @@ func (c *Client) NewCommand() *cobra.Command {
 					root.PersistentPreRun(cmd, args)
 				}
 			}
-			c.Service = c.Servicer.API(cmd).SSHKeys
+			c.Service = *c.Servicer.MetalAPI(cmd).SSHKeysApi
 		},
 	}
 
@@ -59,8 +59,10 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API(*cobra.Command) *packngo.Client
-	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
+	MetalAPI(*cobra.Command) *metal.APIClient
+	Filters() map[string]string
+	Includes(defaultIncludes []string) (incl []string)
+	Excludes(defaultExcludes []string) (excl []string)
 }
 
 func NewClient(s Servicer, out outputs.Outputer) *Client {

--- a/internal/ssh/update.go
+++ b/internal/ssh/update.go
@@ -21,9 +21,10 @@
 package ssh
 
 import (
+	"context"
 	"fmt"
 
-	"github.com/packethost/packngo"
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -42,22 +43,22 @@ func (c *Client) Update() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			req := &packngo.SSHKeyUpdateRequest{}
+			req := metal.NewSSHKeyInput()
 			if key != "" {
-				req.Key = &key
+				req.SetKey(key)
 			}
 
 			if label != "" {
-				req.Label = &label
+				req.SetLabel(label)
 			}
-			sshKey, _, err := c.Service.Update(sshKeyID, req)
+			sshKey, _, err := c.Service.UpdateSSHKey(context.Background(), sshKeyID).Execute()
 			if err != nil {
 				return fmt.Errorf("Could not update SSH Key: %w", err)
 			}
 
 			data := make([][]string, 1)
 
-			data[0] = []string{sshKey.ID, sshKey.Label, sshKey.Created}
+			data[0] = []string{sshKey.GetId(), sshKey.GetLabel(), sshKey.GetCreatedAt().String()}
 			header := []string{"ID", "Label", "Created"}
 
 			return c.Out.Output(sshKey, header, &data)

--- a/test/e2e/ssh_test.go
+++ b/test/e2e/ssh_test.go
@@ -1,0 +1,65 @@
+package e2e
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	root "github.com/equinix/metal-cli/internal/cli"
+	outputPkg "github.com/equinix/metal-cli/internal/outputs"
+	"github.com/equinix/metal-cli/internal/ssh"
+	"github.com/spf13/cobra"
+)
+
+func TestCli_SshKey(t *testing.T) {
+	subCommand := "ssh-key"
+	consumerToken := ""
+	apiURL := ""
+	Version := "metal"
+	rootClient := root.NewClient(consumerToken, apiURL, Version)
+	type fields struct {
+		MainCmd  *cobra.Command
+		Outputer outputPkg.Outputer
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    *cobra.Command
+		cmdFunc func(*testing.T, *cobra.Command)
+	}{
+		{
+			name: "get",
+			fields: fields{
+				MainCmd:  ssh.NewClient(rootClient, outputPkg.Outputer(&outputPkg.Standard{})).NewCommand(),
+				Outputer: outputPkg.Outputer(&outputPkg.Standard{}),
+			},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				root.SetArgs([]string{subCommand, "get"})
+				rescueStdout := os.Stdout
+				r, w, _ := os.Pipe()
+				os.Stdout = w
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				w.Close()
+				out, _ := io.ReadAll(r)
+				os.Stdout = rescueStdout
+				if !strings.Contains(string(out[:]), "ID") &&
+					!strings.Contains(string(out[:]), "LABEL") &&
+					!strings.Contains(string(out[:]), "CREATED") {
+					t.Error("expected output should include ID, LABEL, CREATED")
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd := rootClient.NewCommand()
+			rootCmd.AddCommand(tt.fields.MainCmd)
+			tt.cmdFunc(t, tt.fields.MainCmd)
+		})
+	}
+}


### PR DESCRIPTION
Breakout from https://github.com/equinix/metal-cli/pull/270

What this PR does / why we need it:

This PR replaces packngo with metal-go for all interactions with the Equinix Metal API specifically for SSH key subcommands