### PR TITLE
Bump metal-go from v0.13.0 to v0.16.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/equinix/metal-cli
 go 1.19
 
 require (
-	github.com/equinix-labs/metal-go v0.13.0
+	github.com/equinix-labs/metal-go v0.16.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/packethost/packngo v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/equinix-labs/metal-go v0.13.0 h1:SqMOiz0D81Jv4i1bbkImT1baQ/HA8WQ8QDnwuVuKGVQ=
-github.com/equinix-labs/metal-go v0.13.0/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
+github.com/equinix-labs/metal-go v0.16.0 h1:4YmGx9SRFkDtHiEqRsSjlgJDztV6NHqH1eeaOZcK7d4=
+github.com/equinix-labs/metal-go v0.16.0/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=

--- a/internal/organizations/payment.go
+++ b/internal/organizations/payment.go
@@ -41,7 +41,7 @@ func (c *Client) PaymentMethods() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 
-			paymentMethodsList, _, err := c.Service.FindOrganizationPaymentMethods(context.Background(), organizationID).Include(c.Servicer.Includes(nil)).Exclude(c.Servicer.Excludes(nil)).Execute()
+			paymentMethodsList, _, err := c.Service.FindOrganizationPaymentMethods(context.Background(), organizationID).Include(nil).Execute()
 			if err != nil {
 				return fmt.Errorf("could not list Payment Methods: %w", err)
 			}

--- a/internal/ssh/retrieve.go
+++ b/internal/ssh/retrieve.go
@@ -54,7 +54,7 @@ func (c *Client) Retrieve() *cobra.Command {
 			if sshKeyID == "" {
 				projectID, _ := cmd.LocalFlags().GetString("project-id")
 				listFn := func() (*metal.SSHKeyList, *http.Response, error) {
-					request := c.Service.FindSSHKeys(context.Background()).Include(nil).Exclude(nil)
+					request := c.Service.FindSSHKeys(context.Background()).Include(nil)
 					filters := c.Servicer.Filters()
 					if filters["search"] != "" {
 						request = request.Search(filters["search"])
@@ -85,7 +85,7 @@ func (c *Client) Retrieve() *cobra.Command {
 
 				return c.Out.Output(sshKeysList, header, &data)
 			} else {
-				sshKeyId, _, err := c.Service.FindSSHKeyById(context.Background(), sshKeyID).Include(nil).Exclude(nil).Execute()
+				sshKeyId, _, err := c.Service.FindSSHKeyById(context.Background(), sshKeyID).Include(nil).Execute()
 				if err != nil {
 					return fmt.Errorf("Could not get SSH Key: %w", err)
 				}


### PR DESCRIPTION
# Description:

Updated the Metal-go version and aligned some methods to version V0.16.0 

Closes #317 