### PR TITLE
chore(ci): update e2e test workflow to allow nested directories

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -44,6 +44,6 @@ jobs:
     - name: Get dependencies
       run: go mod download
     - name: Run end-to-end tests
-      run: go test -v -cover -coverpkg=./... -parallel 4 ./test/e2e
+      run: go test -v -cover -coverpkg=./... -parallel 4 ./test/e2e/...
       env:
         METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}


### PR DESCRIPTION
The end-to-end tests for #282 are failing because the tests were moved to nested directories.  This updates the e2e test workflow to not care about how the tests are laid out within the test/e2e directory so that we can move things around freely.