### PR TITLE
chore(ci): cancel in-flight approvals when a PR is updated

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -26,12 +26,16 @@ jobs:
       github.event.pull_request.head.repo.full_name != github.repository &&
       'external' || 'internal' }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.event_name == 'pull_request_target' && format('e2e-authorize-pr-{0}', github.event.pull_request.number) || 'e2e-authorize' }}
+      cancel-in-progress: true
     steps:
       - run: true
 
   e2e-test:
     needs: authorize
     runs-on: ubuntu-latest
+    concurrency: 'e2e-test'
     steps:
     - name: Set up Go
       uses: actions/setup-go@v4


### PR DESCRIPTION
Every time a PR is updated it triggers a new run of the end-to-end tests workflow, which includes making a new deployment request for PRs from forks.  This updates the end-to-end tests workflow so that, when a PR is updated, any in-flight approval jobs are canceled, and only the newest approval request is left running.

In addition, this sets concurrency on the end-to-end test job so that it has to run one-at-a-time to avoid flooding the API with requests if multiple end-to-end test runs are approved.