### PR TITLE
chore: add workflow to enforce Conventional Commit tags

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -1,0 +1,45 @@
+name: "Validate PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
Currently our release process is fairly manual:  someone with write access to this repo has to check out the latest from `main`, look at what has changed since the last release, decide on an appropriate new version number, create a git tag in the correct format (is it `x.y.z` or `vx.y.z`?), and push that tag back up to GitHub to trigger the release process.

By ensuring that our PR titles have Conventional Commit tags, we make it possible to automatically determine the next release version number, which means we can move to a push-button release process: click the release button, and the workflow does the rest.

This workflow has been in place for some time on `metal-go` and was recently adopted in `metal-java`; adopting it more broadly will make it easier for us to safely share the responsibility for releasing our various tools (and could even lead to automated / scheduled release workflows instead of push-button workflows).