### PR TITLE
chore: upgrade metal-go to 0.22.2 and fix enum type errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/equinix/metal-cli
 go 1.19
 
 require (
-	github.com/equinix-labs/metal-go v0.21.0
+	github.com/equinix-labs/metal-go v0.22.2
 	github.com/manifoldco/promptui v0.9.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/packethost/packngo v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/equinix-labs/metal-go v0.21.0 h1:AWmciCaO+tjNKCKB0r4pMHpoGenzAqua3TbXA5VjZE8=
-github.com/equinix-labs/metal-go v0.21.0/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
+github.com/equinix-labs/metal-go v0.22.2 h1:3uVx1tMUb+P9MXcQzmoh5sRM40+Efdtc7yWwlKOh/ms=
+github.com/equinix-labs/metal-go v0.22.2/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=

--- a/internal/devices/create.go
+++ b/internal/devices/create.go
@@ -97,6 +97,17 @@ func (c *Client) Create() *cobra.Command {
 			var facilityArgs []string
 
 			var request metal.ApiCreateDeviceRequest
+
+			var validBillingCycle *metal.DeviceCreateInputBillingCycle
+			var err error
+
+			if billingCycle != "" {
+				validBillingCycle, err = metal.NewDeviceCreateInputBillingCycleFromValue(billingCycle)
+				if err != nil {
+					return err
+				}
+			}
+
 			if facility != "" {
 				facilityArgs = append(facilityArgs, facility)
 
@@ -112,7 +123,7 @@ func (c *Client) Create() *cobra.Command {
 				}
 
 				if billingCycle != "" {
-					facilityDeviceRequest.DeviceCreateInFacilityInput.SetBillingCycle(billingCycle)
+					facilityDeviceRequest.DeviceCreateInFacilityInput.SetBillingCycle(*validBillingCycle)
 				}
 				if alwaysPXE {
 					facilityDeviceRequest.DeviceCreateInFacilityInput.SetAlwaysPxe(alwaysPXE)
@@ -151,7 +162,7 @@ func (c *Client) Create() *cobra.Command {
 					},
 				}
 				if billingCycle != "" {
-					metroDeviceRequest.DeviceCreateInMetroInput.SetBillingCycle(billingCycle)
+					metroDeviceRequest.DeviceCreateInMetroInput.SetBillingCycle(*validBillingCycle)
 				}
 
 				if alwaysPXE {
@@ -182,7 +193,7 @@ func (c *Client) Create() *cobra.Command {
 			}
 			header := []string{"ID", "Hostname", "OS", "State", "Created"}
 			data := make([][]string, 1)
-			data[0] = []string{device.GetId(), device.GetHostname(), *device.GetOperatingSystem().Name, device.GetState(), device.GetCreatedAt().String()}
+			data[0] = []string{device.GetId(), device.GetHostname(), *device.GetOperatingSystem().Name, fmt.Sprintf("%v", device.GetState()), device.GetCreatedAt().String()}
 
 			return c.Out.Output(device, header, &data)
 		},

--- a/internal/devices/retrieve.go
+++ b/internal/devices/retrieve.go
@@ -58,7 +58,7 @@ func (c *Client) Retrieve() *cobra.Command {
 				header := []string{"ID", "Hostname", "OS", "State", "Created"}
 
 				data := make([][]string, 1)
-				data[0] = []string{device.GetId(), device.GetHostname(), device.OperatingSystem.GetName(), device.GetState(), device.GetCreatedAt().String()}
+				data[0] = []string{device.GetId(), device.GetHostname(), device.OperatingSystem.GetName(), fmt.Sprintf("%v", device.GetState()), device.GetCreatedAt().String()}
 
 				return c.Out.Output(device, header, &data)
 			}
@@ -96,7 +96,7 @@ func (c *Client) Retrieve() *cobra.Command {
 			data := make([][]string, len(devices))
 
 			for i, dc := range devices {
-				data[i] = []string{dc.GetId(), dc.GetHostname(), dc.OperatingSystem.GetName(), dc.GetState(), dc.GetCreatedAt().String()}
+				data[i] = []string{dc.GetId(), dc.GetHostname(), dc.OperatingSystem.GetName(), fmt.Sprintf("%v", dc.GetState()), dc.GetCreatedAt().String()}
 			}
 			header := []string{"ID", "Hostname", "OS", "State", "Created"}
 

--- a/internal/devices/update.go
+++ b/internal/devices/update.go
@@ -98,7 +98,7 @@ func (c *Client) Update() *cobra.Command {
 
 			header := []string{"ID", "Hostname", "OS", "State"}
 			data := make([][]string, 1)
-			data[0] = []string{device.GetId(), device.GetHostname(), device.OperatingSystem.GetName(), device.GetState()}
+			data[0] = []string{device.GetId(), device.GetHostname(), device.OperatingSystem.GetName(), fmt.Sprintf("%v", device.GetState())}
 
 			return c.Out.Output(device, header, &data)
 		},

--- a/internal/organizations/retrieve.go
+++ b/internal/organizations/retrieve.go
@@ -44,12 +44,11 @@ func (c *Client) Retrieve() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			include := []string{"Inner_example"}
-			exclude := []string{"Inner_example"}
-			withoutProjects := "withoutProjects_example"
+			include := c.Servicer.Includes(nil)
+			exclude := c.Servicer.Excludes(nil)
 
 			if organizationID == "" {
-				orgs, err := pager.GetAllOrganizations(c.Service, include, exclude, withoutProjects)
+				orgs, err := pager.GetAllOrganizations(c.Service, include, exclude)
 				if err != nil {
 					return fmt.Errorf("Could not list Organizations: %w", err)
 				}

--- a/internal/pagination/pager.go
+++ b/internal/pagination/pager.go
@@ -108,13 +108,13 @@ func GetAllEvents(s metal.ApiFindEventsRequest) ([]metal.Event, error) {
 	}
 }
 
-func GetAllOrganizations(s metal.OrganizationsApiService, include, exclude []string, withOutProjects string) ([]metal.Organization, error) {
+func GetAllOrganizations(s metal.OrganizationsApiService, include, exclude []string) ([]metal.Organization, error) {
 	var orgs []metal.Organization
 	page := int32(1)     // int32 | Page to return (optional) (default to 1)
 	perPage := int32(56) // int32 | Items returned per page (optional) (default to 10)
 
 	for {
-		orgPage, _, err := s.FindOrganizations(context.Background()).Include(include).Exclude(exclude).WithoutProjects(withOutProjects).Page(page).PerPage(perPage).Execute()
+		orgPage, _, err := s.FindOrganizations(context.Background()).Include(include).Exclude(exclude).Page(page).PerPage(perPage).Execute()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/plans/retrieve.go
+++ b/internal/plans/retrieve.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -43,7 +44,11 @@ func (c *Client) Retrieve() *cobra.Command {
 			filters := c.Servicer.Filters()
 
 			if filters["type"] != "" {
-				request = request.Type_(filters["type"])
+				validType, err := metal.NewFindPlansTypeParameterFromValue(filters["type"])
+				if err != nil {
+					return err
+				}
+				request = request.Type_(*validType)
 			}
 
 			if filters["slug"] != "" {


### PR DESCRIPTION
The latest release of metal-go introduced true enum fields.  Previously, metal-go generated enum fields as plain strings due to a bug in openapi-generator.  Now that enum fields are generated as Go enums, we need to convert user-provided string values for those fields to the correct enum type for input and we need to convert the enum values to plain strings for output.

This updates metal-go to the latest release and addresses type errors for metal-go client code as it exists in the `main` branch; PRs that introduce metal-go elsewhere in the CLI may need to be updated as well before they can be merged. 