### PR TITLE
chore: Migrate ports command from packngo to metal-go client

### DIFF
--- a/internal/ports/port.go
+++ b/internal/ports/port.go
@@ -21,8 +21,9 @@
 package ports
 
 import (
-	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/equinix/metal-cli/internal/outputs"
+
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/ports/port.go
+++ b/internal/ports/port.go
@@ -21,15 +21,15 @@
 package ports
 
 import (
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/equinix/metal-cli/internal/outputs"
-	"github.com/packethost/packngo"
 	"github.com/spf13/cobra"
 )
 
 type Client struct {
 	Servicer    Servicer
-	PortService packngo.PortService
-	VLANService packngo.VLANAssignmentService
+	PortService *metal.PortsApiService
+	VLANService *metal.VLANsApiService
 	Out         outputs.Outputer
 }
 
@@ -45,8 +45,8 @@ func (c *Client) NewCommand() *cobra.Command {
 					root.PersistentPreRun(cmd, args)
 				}
 			}
-			c.PortService = c.Servicer.API(cmd).Ports
-			c.VLANService = c.Servicer.API(cmd).VLANAssignments
+			c.PortService = c.Servicer.MetalAPI(cmd).PortsApi
+			c.VLANService = c.Servicer.MetalAPI(cmd).VLANsApi
 		},
 	}
 
@@ -59,8 +59,9 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API(*cobra.Command) *packngo.Client
-	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
+	MetalAPI(*cobra.Command) *metal.APIClient
+	Filters() map[string]string
+	Includes(defaultIncludes []string) (incl []string)
 }
 
 func NewClient(s Servicer, out outputs.Outputer) *Client {

--- a/internal/ports/retrieve.go
+++ b/internal/ports/retrieve.go
@@ -21,10 +21,10 @@
 package ports
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
-	"github.com/packethost/packngo"
 	"github.com/spf13/cobra"
 )
 
@@ -41,17 +41,16 @@ func (c *Client) Retrieve() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			listOpts := c.Servicer.ListOptions(nil, nil)
-
-			getOpts := &packngo.GetOptions{Includes: listOpts.Includes, Excludes: listOpts.Excludes}
-			port, _, err := c.PortService.Get(portID, getOpts)
+			port, _, err := c.PortService.FindPortById(context.Background(), portID).
+				Include(c.Servicer.Includes(nil)).
+				Execute()
 			if err != nil {
 				return fmt.Errorf("Could not get Port: %w", err)
 			}
 
 			data := make([][]string, 1)
 
-			data[0] = []string{port.ID, port.Name, port.Type, port.NetworkType, port.Data.MAC, strconv.FormatBool(port.Data.Bonded)}
+			data[0] = []string{port.GetId(), port.GetName(), string(port.GetType()), string(port.GetNetworkType()), port.Data.GetMac(), strconv.FormatBool(port.Data.GetBonded())}
 			header := []string{"ID", "Name", "Type", "Network Type", "MAC", "Bonded"}
 
 			return c.Out.Output(port, header, &data)

--- a/test/e2e/ports/convert_test.go
+++ b/test/e2e/ports/convert_test.go
@@ -123,6 +123,7 @@ func TestPorts_Convert(t *testing.T) {
 	}
 }
 
+//nolint:staticcheck
 func setupProjectAndDevice(t *testing.T, projectId, deviceId *string) []metal.Port {
 	projId, err := helper.CreateTestProject("metal-cli-test-ports-project")
 	if err != nil {

--- a/test/e2e/ports/convert_test.go
+++ b/test/e2e/ports/convert_test.go
@@ -7,14 +7,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/equinix/metal-cli/internal/ports"
-
-	metal "github.com/equinix-labs/metal-go/metal/v1"
-
 	root "github.com/equinix/metal-cli/internal/cli"
 	outputPkg "github.com/equinix/metal-cli/internal/outputs"
+	"github.com/equinix/metal-cli/internal/ports"
 	"github.com/equinix/metal-cli/test/helper"
 
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -26,8 +24,8 @@ func TestPorts_Convert(t *testing.T) {
 	Version := "devel"
 	rootClient := root.NewClient(consumerToken, apiURL, Version)
 
-	portList := setupProjectAndDevice(t, &projectId, &deviceId)
-	port := &portList[2]
+	device := helper.SetupProjectAndDevice(t, &projectId, &deviceId)
+	port := &device.GetNetworkPorts()[2]
 	defer func() {
 		if err := helper.CleanupProjectAndDevice(deviceId, projectId); err != nil {
 			t.Error(err)
@@ -121,40 +119,6 @@ func TestPorts_Convert(t *testing.T) {
 			tt.cmdFunc(t, tt.cmd)
 		})
 	}
-}
-
-//nolint:staticcheck
-func setupProjectAndDevice(t *testing.T, projectId, deviceId *string) []metal.Port {
-	projId, err := helper.CreateTestProject("metal-cli-test-ports-project")
-	if err != nil {
-		t.Error(err)
-	}
-	projectId = &projId
-
-	devId, err := helper.CreateTestDevice(*projectId, "metal-cli-test-ports-device")
-	if err != nil {
-		t.Error(err)
-	}
-	deviceId = &devId
-
-	active, err := helper.IsDeviceStateActive(*deviceId)
-	if err != nil {
-		t.Error(err)
-	}
-	if !active {
-		t.Errorf("Timeout while waiting for device: %s to be active", *deviceId)
-	}
-
-	device, err := helper.GetDeviceById(*deviceId)
-	if err != nil {
-		t.Error(err)
-		return nil
-	}
-	if len(device.NetworkPorts) < 3 {
-		t.Errorf("All 3 ports doesnot exist for the created device: %s", device.GetId())
-	}
-
-	return device.GetNetworkPorts()
 }
 
 func assertPortCmdOutput(t *testing.T, port *metal.Port, out, networkType string, bonded bool) {

--- a/test/e2e/ports/convert_test.go
+++ b/test/e2e/ports/convert_test.go
@@ -1,0 +1,175 @@
+package ports
+
+import (
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/equinix/metal-cli/internal/ports"
+
+	metal "github.com/equinix-labs/metal-go/metal/v1"
+
+	root "github.com/equinix/metal-cli/internal/cli"
+	outputPkg "github.com/equinix/metal-cli/internal/outputs"
+	"github.com/equinix/metal-cli/test/helper"
+
+	"github.com/spf13/cobra"
+)
+
+func TestPorts_Convert(t *testing.T) {
+	var projectId, deviceId string
+	subCommand := "port"
+	consumerToken := ""
+	apiURL := ""
+	Version := "devel"
+	rootClient := root.NewClient(consumerToken, apiURL, Version)
+
+	portList := setupProjectAndDevice(t, &projectId, &deviceId)
+	port := &portList[2]
+	defer func() {
+		if err := helper.CleanupProjectAndDevice(deviceId, projectId); err != nil {
+			t.Error(err)
+		}
+	}()
+	if port == nil {
+		t.Error("bond0 Port not found on device")
+		return
+	}
+
+	tests := []struct {
+		name                string
+		cmd                 *cobra.Command
+		want                *cobra.Command
+		cmdFunc             func(*testing.T, *cobra.Command)
+		expectedNetworkType string
+		expectedBonded      bool
+	}{
+		{
+			name: "convert port layer-2 bonded false",
+			cmd:  ports.NewClient(rootClient, outputPkg.Outputer(&outputPkg.Standard{})).NewCommand(),
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+
+				root.SetArgs([]string{subCommand, "convert", "-i", port.GetId(), "--layer2", "--bonded=false", "--force"})
+
+				rescueStdout := os.Stdout
+				r, w, _ := os.Pipe()
+				os.Stdout = w
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				w.Close()
+				out, _ := io.ReadAll(r)
+				os.Stdout = rescueStdout
+
+				assertPortCmdOutput(t, port, string(out[:]), "layer2-individual", false)
+			},
+		},
+		{
+			name: "convert port layer-2 bonded true",
+			cmd:  ports.NewClient(rootClient, outputPkg.Outputer(&outputPkg.Standard{})).NewCommand(),
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+
+				root.SetArgs([]string{subCommand, "convert", "-i", port.GetId(), "--layer2", "--bonded", "--force"})
+
+				rescueStdout := os.Stdout
+				r, w, _ := os.Pipe()
+				os.Stdout = w
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				w.Close()
+				out, _ := io.ReadAll(r)
+				os.Stdout = rescueStdout
+
+				assertPortCmdOutput(t, port, string(out[:]), "layer2-bonded", true)
+			},
+		},
+		{
+			name: "convert port layer-3 bonded true",
+			cmd:  ports.NewClient(rootClient, outputPkg.Outputer(&outputPkg.Standard{})).NewCommand(),
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+
+				root.SetArgs([]string{subCommand, "convert", "-i", port.GetId(), "-2=false", "--force"})
+
+				rescueStdout := os.Stdout
+				r, w, _ := os.Pipe()
+				os.Stdout = w
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				w.Close()
+				out, _ := io.ReadAll(r)
+				os.Stdout = rescueStdout
+
+				assertPortCmdOutput(t, port, string(out[:]), "layer3", true)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd := rootClient.NewCommand()
+			rootCmd.AddCommand(tt.cmd)
+			tt.cmdFunc(t, tt.cmd)
+		})
+	}
+}
+
+func setupProjectAndDevice(t *testing.T, projectId, deviceId *string) []metal.Port {
+	projId, err := helper.CreateTestProject("metal-cli-test-ports-project")
+	if err != nil {
+		t.Error(err)
+	}
+	projectId = &projId
+
+	devId, err := helper.CreateTestDevice(*projectId, "metal-cli-test-ports-device")
+	if err != nil {
+		t.Error(err)
+	}
+	deviceId = &devId
+
+	active, err := helper.IsDeviceStateActive(*deviceId)
+	if err != nil {
+		t.Error(err)
+	}
+	if !active {
+		t.Errorf("Timeout while waiting for device: %s to be active", *deviceId)
+	}
+
+	device, err := helper.GetDeviceById(*deviceId)
+	if err != nil {
+		t.Error(err)
+		return nil
+	}
+	if len(device.NetworkPorts) < 3 {
+		t.Errorf("All 3 ports doesnot exist for the created device: %s", device.GetId())
+	}
+
+	return device.GetNetworkPorts()
+}
+
+func assertPortCmdOutput(t *testing.T, port *metal.Port, out, networkType string, bonded bool) {
+	if !strings.Contains(out, port.GetId()) {
+		t.Errorf("cmd output should contain ID of the port: %s", port.GetId())
+	}
+
+	if !strings.Contains(out, port.GetName()) {
+		t.Errorf("cmd output should contain name of the port: %s", port.GetName())
+	}
+
+	if !strings.Contains(out, networkType) {
+		t.Errorf("cmd output should contain type of the port: %s", string(port.GetNetworkType()))
+	}
+
+	if !strings.Contains(out, strconv.FormatBool(bonded)) {
+		t.Errorf("cmd output should contain if port is bonded: %s", strconv.FormatBool(port.Data.GetBonded()))
+	}
+}

--- a/test/e2e/ports/retrieve_test.go
+++ b/test/e2e/ports/retrieve_test.go
@@ -22,8 +22,8 @@ func TestPorts_Retrieve(t *testing.T) {
 	Version := "devel"
 	rootClient := root.NewClient(consumerToken, apiURL, Version)
 
-	portList := setupProjectAndDevice(t, &projectId, &deviceId)
-	port := &portList[2]
+	device := helper.SetupProjectAndDevice(t, &projectId, &deviceId)
+	port := &device.GetNetworkPorts()[2]
 	defer func() {
 		if err := helper.CleanupProjectAndDevice(deviceId, projectId); err != nil {
 			t.Error(err)

--- a/test/e2e/ports/retrieve_test.go
+++ b/test/e2e/ports/retrieve_test.go
@@ -1,0 +1,77 @@
+package ports
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	root "github.com/equinix/metal-cli/internal/cli"
+	outputPkg "github.com/equinix/metal-cli/internal/outputs"
+	"github.com/equinix/metal-cli/internal/ports"
+	"github.com/equinix/metal-cli/test/helper"
+
+	"github.com/spf13/cobra"
+)
+
+func TestPorts_Retrieve(t *testing.T) {
+	var projectId, deviceId string
+	subCommand := "port"
+	consumerToken := ""
+	apiURL := ""
+	Version := "devel"
+	rootClient := root.NewClient(consumerToken, apiURL, Version)
+
+	portList := setupProjectAndDevice(t, &projectId, &deviceId)
+	port := &portList[2]
+	defer func() {
+		if err := helper.CleanupProjectAndDevice(deviceId, projectId); err != nil {
+			t.Error(err)
+		}
+	}()
+	if port == nil {
+		t.Error("bond0 Port not found on device")
+		return
+	}
+
+	tests := []struct {
+		name    string
+		cmd     *cobra.Command
+		want    *cobra.Command
+		cmdFunc func(*testing.T, *cobra.Command)
+	}{
+		{
+			name: "retrieve port",
+			cmd:  ports.NewClient(rootClient, outputPkg.Outputer(&outputPkg.Standard{})).NewCommand(),
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				root.SetArgs([]string{subCommand, "get", "-i", port.GetId()})
+
+				rescueStdout := os.Stdout
+				r, w, _ := os.Pipe()
+				os.Stdout = w
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				w.Close()
+				out, _ := io.ReadAll(r)
+				os.Stdout = rescueStdout
+
+				if !strings.Contains(string(out[:]), port.Data.GetMac()) {
+					t.Errorf("cmd output should contain MAC address of the port: %s", port.Data.GetMac())
+				}
+
+				assertPortCmdOutput(t, port, string(out[:]), string(port.GetNetworkType()), port.Data.GetBonded())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd := rootClient.NewCommand()
+			rootCmd.AddCommand(tt.cmd)
+			tt.cmdFunc(t, tt.cmd)
+		})
+	}
+}

--- a/test/e2e/ports/vlans_test.go
+++ b/test/e2e/ports/vlans_test.go
@@ -1,0 +1,91 @@
+package ports
+
+import (
+	"io"
+	"os"
+	"strconv"
+	"testing"
+
+	root "github.com/equinix/metal-cli/internal/cli"
+	outputPkg "github.com/equinix/metal-cli/internal/outputs"
+	"github.com/equinix/metal-cli/internal/ports"
+	"github.com/equinix/metal-cli/test/helper"
+
+	"github.com/spf13/cobra"
+)
+
+func TestPorts_VLANs(t *testing.T) {
+	var projectId, deviceId string
+	subCommand := "port"
+	consumerToken := ""
+	apiURL := ""
+	Version := "devel"
+	rootClient := root.NewClient(consumerToken, apiURL, Version)
+
+	portList := setupProjectAndDevice(t, &projectId, &deviceId)
+	port := &portList[2]
+	vlan, err := helper.CreateTestVLAN(projectId)
+	if err != nil {
+		t.Error(err)
+	}
+
+	defer func() {
+		if err := helper.UnAssignPortVlan(port.GetId(), vlan.GetId()); err != nil {
+			t.Error(err)
+			return
+		}
+		if err := helper.CleanupProjectAndDevice(deviceId, projectId); err != nil {
+			t.Error(err)
+		}
+	}()
+	if port == nil {
+		t.Error("bond0 Port not found on device")
+		return
+	}
+
+	tests := []struct {
+		name    string
+		cmd     *cobra.Command
+		want    *cobra.Command
+		cmdFunc func(*testing.T, *cobra.Command)
+	}{
+		{
+			name: "vlan assignment port",
+			cmd:  ports.NewClient(rootClient, outputPkg.Outputer(&outputPkg.Standard{})).NewCommand(),
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+
+				vxLanStr := strconv.Itoa(int(vlan.GetVxlan()))
+				// should be hybrid-bonded
+				root.SetArgs([]string{subCommand, "vlan", "-i", port.GetId(), "-a", vxLanStr})
+
+				rescueStdout := os.Stdout
+				r, w, _ := os.Pipe()
+				os.Stdout = w
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				w.Close()
+				out, _ := io.ReadAll(r)
+				os.Stdout = rescueStdout
+
+				// wait for port to have vlans attached
+				if err := helper.WaitForAttachVlanToPort(port.GetId(), true); err != nil {
+					t.Error(err)
+					return
+				}
+
+				assertPortCmdOutput(t, port, string(out[:]), "hybrid-bonded", true)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd := rootClient.NewCommand()
+			rootCmd.AddCommand(tt.cmd)
+			tt.cmdFunc(t, tt.cmd)
+		})
+	}
+}

--- a/test/e2e/vlan/vlan_delete_test.go
+++ b/test/e2e/vlan/vlan_delete_test.go
@@ -44,7 +44,7 @@ func TestCli_Vlan_Clean(t *testing.T) {
 				if err != nil {
 					t.Error(err)
 				}
-				vlanId, err = helper.CreateTestVlan(projectId, 2023, "metal-cli-vlan-get-test")
+				vlanId, err = helper.CreateTestVlanWithVxLan(projectId, 2023, "metal-cli-vlan-get-test")
 				if len(projectId) != 0 && len(vlanId) != 0 {
 					root.SetArgs([]string{subCommand, "delete", "-f", "-i", vlanId})
 					rescueStdout := os.Stdout

--- a/test/e2e/vlan/vlan_get_test.go
+++ b/test/e2e/vlan/vlan_get_test.go
@@ -44,7 +44,7 @@ func TestCli_Vlan_Get(t *testing.T) {
 				if err != nil {
 					t.Error(err)
 				}
-				vlanId, err = helper.CreateTestVlan(projectId, 2023, "metal-cli-vlan-delete-test")
+				vlanId, err = helper.CreateTestVlanWithVxLan(projectId, 2023, "metal-cli-vlan-delete-test")
 				if len(projectId) != 0 && len(vlanId) != 0 {
 					root.SetArgs([]string{subCommand, "get", "-p", projectId})
 					rescueStdout := os.Stdout


### PR DESCRIPTION
Issue Task as part of migrating metal-cli from packngo to metal-go client, added the support of ports subcommand to use metal-go
Part of: https://github.com/equinix/metal-cli/issues/333

Discussion:
As of metal-go 0.22.2 there is 1 issue which needs api support
- All the APIs such as `FindPortById`, `BondPort`, `DisbondPort`, `CreatePortVlanAssignmentBatch` etc needs to support `Exclude([]string)` parameter as well. It only supports `Includes([]string)`