### PR TITLE
fix: output for convert layer2 to layer 3 command

### DIFF
--- a/internal/ports/convert.go
+++ b/internal/ports/convert.go
@@ -95,7 +95,7 @@ func (c *Client) Convert() *cobra.Command {
 			}
 
 			convToL3 := func(portID string) (*metal.Port, *http.Response, error) {
-				log.Printf("Converting port %s to layer-3 with addresses %v", portID, addrs)
+				log.Printf("Converting port %s to layer-3", portID)
 				return c.PortService.
 					ConvertLayer3(context.Background(), portID).
 					PortConvertLayer3Input(metal.PortConvertLayer3Input{


### PR DESCRIPTION
metal-cli Convert subcommand from layer 2 to layer 3 logs pointers for the addresses

Fixes: https://github.com/equinix/metal-cli/issues/386 and https://github.com/equinix/metal-cli/issues/387