### PR TITLE
feat: add METAL_CONFIG as alternative to --config

### DIFF
--- a/docs/metal.md
+++ b/docs/metal.md
@@ -9,7 +9,7 @@ Command line interface for Equinix Metal
 ### Options
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
   -h, --help                  help for metal

--- a/docs/metal_2fa.md
+++ b/docs/metal_2fa.md
@@ -15,7 +15,7 @@ Enable or disable two-factor authentication on your user account or receive an O
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_2fa_disable.md
+++ b/docs/metal_2fa_disable.md
@@ -32,7 +32,7 @@ metal 2fa disable (-a | -s) --code <OTP_code>  [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_2fa_enable.md
+++ b/docs/metal_2fa_enable.md
@@ -32,7 +32,7 @@ metal 2fa enable (-s | -a) --code <OTP_code> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_2fa_receive.md
+++ b/docs/metal_2fa_receive.md
@@ -31,7 +31,7 @@ metal 2fa receive (-s | -a) [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_capacity.md
+++ b/docs/metal_capacity.md
@@ -15,7 +15,7 @@ Capacity operations. For more information on capacity in metros, visit https://m
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_capacity_check.md
+++ b/docs/metal_capacity_check.md
@@ -33,7 +33,7 @@ metal capacity check (-m <metro> | -f <facility>) -P <plan> -q <quantity> [flags
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_capacity_get.md
+++ b/docs/metal_capacity_get.md
@@ -37,7 +37,7 @@ metal capacity get [-m | -f] | [--metros <list> | --facilities <list>] [-P <list
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_completion.md
+++ b/docs/metal_completion.md
@@ -47,7 +47,7 @@ metal completion [bash | zsh | fish | powershell]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_device.md
+++ b/docs/metal_device.md
@@ -15,7 +15,7 @@ Device operations that control server provisioning, metadata, and basic operatio
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_device_create.md
+++ b/docs/metal_device_create.md
@@ -47,7 +47,7 @@ metal device create -p <project_id> (-m <metro> | -f <facility>) -P <plan> -H <h
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_device_delete.md
+++ b/docs/metal_device_delete.md
@@ -33,7 +33,7 @@ metal device delete -i <device_id> [-f] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_device_get.md
+++ b/docs/metal_device_get.md
@@ -34,7 +34,7 @@ metal device get [-p <project_id>] | [-i <device_id>] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_device_reboot.md
+++ b/docs/metal_device_reboot.md
@@ -27,7 +27,7 @@ metal device reboot -i <device_id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_device_reinstall.md
+++ b/docs/metal_device_reinstall.md
@@ -33,7 +33,7 @@ metal device reinstall --id <device-id> [--operating-system <os_slug>] [--deprov
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_device_start.md
+++ b/docs/metal_device_start.md
@@ -27,7 +27,7 @@ metal device start -i <device_id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_device_stop.md
+++ b/docs/metal_device_stop.md
@@ -27,7 +27,7 @@ metal device stop -i <device_id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_device_update.md
+++ b/docs/metal_device_update.md
@@ -36,7 +36,7 @@ metal device update -i <device_id> [-H <hostname>] [-d <description>] [--locked 
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_docs.md
+++ b/docs/metal_docs.md
@@ -26,7 +26,7 @@ metal docs <destination>
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_emdocs.md
+++ b/docs/metal_emdocs.md
@@ -26,7 +26,7 @@ metal emdocs <destination>
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_env.md
+++ b/docs/metal_env.md
@@ -42,7 +42,7 @@ metal env [-p <project_id>]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_event.md
+++ b/docs/metal_event.md
@@ -15,7 +15,7 @@ Events information for organizations, projects, devices, and the current user.
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_event_get.md
+++ b/docs/metal_event_get.md
@@ -42,7 +42,7 @@ metal event get [-p <project_id>] | [-d <device_id>] | [-i <event_id>] | [-O <or
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_facilities.md
+++ b/docs/metal_facilities.md
@@ -15,7 +15,7 @@ Information about specific facilities. Facility-level operations have mostly bee
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_facilities_get.md
+++ b/docs/metal_facilities_get.md
@@ -26,7 +26,7 @@ metal facilities get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_gateway.md
+++ b/docs/metal_gateway.md
@@ -15,7 +15,7 @@ A Metal Gateway provides a single IPv4 address as a gateway for a subnet. For mo
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_gateway_create.md
+++ b/docs/metal_gateway_create.md
@@ -33,7 +33,7 @@ metal gateway create -p <project_UUID> --virtual-network <virtual_network_UUID> 
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_gateway_delete.md
+++ b/docs/metal_gateway_delete.md
@@ -33,7 +33,7 @@ metal gateway delete -i <metal_gateway_UUID> [-f] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_gateway_get.md
+++ b/docs/metal_gateway_get.md
@@ -28,7 +28,7 @@ metal gateway get -p <project_UUID> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_hardware-reservation.md
+++ b/docs/metal_hardware-reservation.md
@@ -15,7 +15,7 @@ Information and operations on Hardware Reservations. Provisioning specific devic
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_hardware-reservation_get.md
+++ b/docs/metal_hardware-reservation_get.md
@@ -31,7 +31,7 @@ metal hardware-reservation get [-p <project_id>] | [-i <hardware_reservation_id>
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_hardware-reservation_move.md
+++ b/docs/metal_hardware-reservation_move.md
@@ -28,7 +28,7 @@ metal hardware-reservation move -i <hardware_reservation_id> -p <project_id> [fl
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_init.md
+++ b/docs/metal_init.md
@@ -29,7 +29,7 @@ metal init
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_interconnections.md
+++ b/docs/metal_interconnections.md
@@ -15,7 +15,7 @@ Get information on Metro locations. For more information on https://deploy.equin
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_interconnections_create.md
+++ b/docs/metal_interconnections_create.md
@@ -37,7 +37,7 @@ metal interconnections create -n <name> [-m <metro>] [-r <redundancy> ] [-t <typ
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_interconnections_delete.md
+++ b/docs/metal_interconnections_delete.md
@@ -27,7 +27,7 @@ metal interconnections delete -i <connection_id>  [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_interconnections_get.md
+++ b/docs/metal_interconnections_get.md
@@ -37,7 +37,7 @@ metal interconnections get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_interconnections_update.md
+++ b/docs/metal_interconnections_update.md
@@ -33,7 +33,7 @@ metal interconnections update -i <connection_id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_ip.md
+++ b/docs/metal_ip.md
@@ -15,7 +15,7 @@ IP address and subnet operations, including requesting IPv4 and IPv6 addresses, 
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_ip_assign.md
+++ b/docs/metal_ip_assign.md
@@ -28,7 +28,7 @@ metal ip assign -a <IP_address> -d <device_UUID> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_ip_available.md
+++ b/docs/metal_ip_available.md
@@ -28,7 +28,7 @@ metal ip available -r <reservation_UUID> -c <size_of_subnet> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_ip_get.md
+++ b/docs/metal_ip_get.md
@@ -35,7 +35,7 @@ metal ip get -p <project_UUID> | -a <assignment_UUID> | -r <reservation_UUID> [f
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_ip_remove.md
+++ b/docs/metal_ip_remove.md
@@ -27,7 +27,7 @@ metal ip remove -i <reservation_UUID> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_ip_request.md
+++ b/docs/metal_ip_request.md
@@ -33,7 +33,7 @@ metal ip request -p <project_id> -t <ip_address_type> -q <quantity> (-m <metro> 
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_ip_unassign.md
+++ b/docs/metal_ip_unassign.md
@@ -27,7 +27,7 @@ metal ip unassign -i <assignment_UUID>  [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_metros.md
+++ b/docs/metal_metros.md
@@ -15,7 +15,7 @@ Get information on Metro locations. For more information on https://metal.equini
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_metros_get.md
+++ b/docs/metal_metros_get.md
@@ -26,7 +26,7 @@ metal metros get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_operating-systems.md
+++ b/docs/metal_operating-systems.md
@@ -15,7 +15,7 @@ Information on available operating systems. For more information on which operat
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_operating-systems_get.md
+++ b/docs/metal_operating-systems_get.md
@@ -26,7 +26,7 @@ metal operating-systems get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_organization.md
+++ b/docs/metal_organization.md
@@ -15,7 +15,7 @@ Information and management of Organization-level settings. Documentation on orga
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_organization_create.md
+++ b/docs/metal_organization_create.md
@@ -34,7 +34,7 @@ metal organization create -n <name> [-d <description>] [-w <website_URL>] [-t <t
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_organization_delete.md
+++ b/docs/metal_organization_delete.md
@@ -33,7 +33,7 @@ metal organization delete -i <organization_UUID> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_organization_get.md
+++ b/docs/metal_organization_get.md
@@ -30,7 +30,7 @@ metal organization get -i <organization_UUID> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_organization_payment-methods.md
+++ b/docs/metal_organization_payment-methods.md
@@ -27,7 +27,7 @@ metal organization payment-methods -i <organization_UUID> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_organization_update.md
+++ b/docs/metal_organization_update.md
@@ -32,7 +32,7 @@ metal organization update -i <organization_UUID> [-n <name>] [-d <description>] 
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_plan.md
+++ b/docs/metal_plan.md
@@ -15,7 +15,7 @@ Information on server plans. For more information on the different Equinix Metal
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_plan_get.md
+++ b/docs/metal_plan_get.md
@@ -26,7 +26,7 @@ metal plan get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_port.md
+++ b/docs/metal_port.md
@@ -15,7 +15,7 @@ Information and operations for converting ports between networking modes and man
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_port_convert.md
+++ b/docs/metal_port_convert.md
@@ -42,7 +42,7 @@ metal port convert -i <port_UUID> [--bonded] [--bulk] --layer2 [--force] [--publ
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_port_get.md
+++ b/docs/metal_port_get.md
@@ -27,7 +27,7 @@ metal port get -i <port_UUID> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_port_vlan.md
+++ b/docs/metal_port_vlan.md
@@ -36,7 +36,7 @@ metal port vlan -i <port_UUID> [--native <vlan>] [--unassign <vlan>]... [--assig
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_project.md
+++ b/docs/metal_project.md
@@ -15,7 +15,7 @@ Information and management for Projects and Project-level BGP. Documentation on 
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_project_bgp-config.md
+++ b/docs/metal_project_bgp-config.md
@@ -26,7 +26,7 @@ metal project bgp-config --project-id <project_UUID> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_project_bgp-enable.md
+++ b/docs/metal_project_bgp-enable.md
@@ -30,7 +30,7 @@ metal project bgp-enable --project-id <project_UUID> --deployment-type <deployme
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_project_bgp-sessions.md
+++ b/docs/metal_project_bgp-sessions.md
@@ -26,7 +26,7 @@ metal project bgp-sessions --project-id <project_UUID> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_project_create.md
+++ b/docs/metal_project_create.md
@@ -32,7 +32,7 @@ metal project create -n <project_name> [-O <organization_UUID>] [-m <payment_met
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_project_delete.md
+++ b/docs/metal_project_delete.md
@@ -33,7 +33,7 @@ metal project delete --id <project_UUID> [--force] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_project_get.md
+++ b/docs/metal_project_get.md
@@ -34,7 +34,7 @@ metal project get [-i <project_UUID> | -n <project_name>] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_project_update.md
+++ b/docs/metal_project_update.md
@@ -32,7 +32,7 @@ metal project update -i <project_UUID> [-n <name>] [-m <payment_method_UUID>] [f
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_ssh-key.md
+++ b/docs/metal_ssh-key.md
@@ -15,7 +15,7 @@ SSH key operations for managing SSH keys on user accounts and projects. Keys add
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_ssh-key_create.md
+++ b/docs/metal_ssh-key_create.md
@@ -28,7 +28,7 @@ metal ssh-key create --key <public_key> --label <label> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_ssh-key_delete.md
+++ b/docs/metal_ssh-key_delete.md
@@ -33,7 +33,7 @@ metal ssh-key delete --id <SSH-key_UUID> [--force] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_ssh-key_get.md
+++ b/docs/metal_ssh-key_get.md
@@ -35,7 +35,7 @@ metal ssh-key get [-i <SSH-key_UUID>] [-P] [-p <project_id>] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_ssh-key_update.md
+++ b/docs/metal_ssh-key_update.md
@@ -32,7 +32,7 @@ metal ssh-key update -i <SSH-key_UUID> [-k <public_key>] [-l <label>] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_user.md
+++ b/docs/metal_user.md
@@ -15,7 +15,7 @@ Adding users or getting their details. For more information on user and account 
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_user_add.md
+++ b/docs/metal_user_add.md
@@ -31,7 +31,7 @@ metal user add --email <email> --roles <roles> [--organization-id <organization_
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_user_get.md
+++ b/docs/metal_user_get.md
@@ -30,7 +30,7 @@ metal user get [-i <user_UUID>] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_virtual-network.md
+++ b/docs/metal_virtual-network.md
@@ -15,7 +15,7 @@ Managing Virtual Networks on a Project. VLAN assignments to a server's ports is 
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_virtual-network_create.md
+++ b/docs/metal_virtual-network_create.md
@@ -34,7 +34,7 @@ metal virtual-network create -p <project_UUID>  [-m <metro_code> -vxlan <vlan> |
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_virtual-network_delete.md
+++ b/docs/metal_virtual-network_delete.md
@@ -33,7 +33,7 @@ metal virtual-network delete -i <virtual_network_UUID> [-f] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_virtual-network_get.md
+++ b/docs/metal_virtual-network_get.md
@@ -27,7 +27,7 @@ metal virtual-network get -p <project_UUID> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_vrf.md
+++ b/docs/metal_vrf.md
@@ -15,7 +15,7 @@ VRF operations : It defines a collection of customer-managed IP blocks that can 
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_vrf_create.md
+++ b/docs/metal_vrf_create.md
@@ -34,7 +34,7 @@ metal vrf create [-p <project_id] [-d <description>] [-m <metro>] [-n <name>] [-
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_vrf_delete.md
+++ b/docs/metal_vrf_delete.md
@@ -33,7 +33,7 @@ metal vrf delete vrf -i <metal_vrf_UUID> [-f] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)

--- a/docs/metal_vrf_get.md
+++ b/docs/metal_vrf_get.md
@@ -32,7 +32,7 @@ metal vrf get -p <project_Id>  [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string         Path to JSON or YAML configuration file
+      --config string         Path to JSON or YAML configuration file (METAL_CONFIG)
       --exclude strings       Comma separated Href references to collapse in results, may be dotted three levels deep
       --filter stringArray    Filter 'get' actions with name value pairs. Filter is not supported by all resources and is implemented as request query parameters.
       --http-header strings   Headers to add to requests (in format key=value)


### PR DESCRIPTION
Nearly all --args can be supplied as METAL_{ARG} because we take advantage of Viper's AutomaticEnv feature.
    
The code that configures this and runs this happens after the config file option is detected and read in.

In order to support METAL_CONFIG, we have to check for it explicitly.

Fixes #360 

## How has this been tested

```sh
mjohansson@dev-qemu:~/dev/metal-cli$ METAL_CONFIG=/tmp/foo.yaml  go run ./cmd/metal env
METAL_AUTH_TOKEN=foo
METAL_ORGANIZATION_ID=
METAL_PROJECT_ID=
METAL_CONFIG=/tmp/foo.yaml

mjohansson@dev-qemu:~/dev/metal-cli$ go run ./cmd/metal env --config=/tmp/foo.yaml
METAL_AUTH_TOKEN=foo
METAL_ORGANIZATION_ID=
METAL_PROJECT_ID=
METAL_CONFIG=/tmp/foo.yaml

mjohansson@dev-qemu:~/dev/metal-cli$ go run ./cmd/metal env | grep CONFIG
METAL_CONFIG=/home/mjohansson/.config/equinix/metal.yaml
```