### PR TITLE
test: use TerminationTime to sweep devices in E2E tests

### DIFF
--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -20,7 +20,7 @@ func TestClient() *metalv1.APIClient {
 	configuration := metalv1.NewConfiguration()
 	configuration.AddDefaultHeader("X-Auth-Token", os.Getenv("METAL_AUTH_TOKEN"))
 	// For debug purpose
-	//configuration.Debug = true
+	// configuration.Debug = true
 	apiClient := metalv1.NewAPIClient(configuration)
 	return apiClient
 }
@@ -49,12 +49,14 @@ func CreateTestDevice(t *testing.T, projectId, name string) *metalv1.Device {
 	TestApiClient := TestClient()
 
 	hostname := name
+	termination := time.Now().Add(1 * time.Hour)
 	metroDeviceRequest := metalv1.CreateDeviceRequest{
 		DeviceCreateInMetroInput: &metalv1.DeviceCreateInMetroInput{
 			Metro:           "sv",
 			Plan:            "m3.small.x86",
 			OperatingSystem: "ubuntu_20_04",
 			Hostname:        &hostname,
+			TerminationTime: &termination,
 		},
 	}
 	device, _, err := TestApiClient.DevicesApi.


### PR DESCRIPTION
The E2E tests have not been good about cleaning up their devices and projects. By taking advantage of the TerminationTime feature of Equinix Metal device deployments, we can ensure that the resources are swept up even when our sweeping processes fail.

1 Hour was chosen because this is longer than we permit for E2E tests in metal-cli today. (I've seen 15m timeouts)

A similar process is used for Terraform E2E tests.