### PR TITLE
chore: refactor tests to fix timeouts and improve cleanup

### DIFF
--- a/test/e2e/capacitytest/capacity_test.go
+++ b/test/e2e/capacitytest/capacity_test.go
@@ -1,14 +1,13 @@
 package capacitytest
 
 import (
-	"io"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/equinix/metal-cli/internal/capacity"
 	root "github.com/equinix/metal-cli/internal/cli"
 	outputPkg "github.com/equinix/metal-cli/internal/outputs"
+	"github.com/equinix/metal-cli/test/helper"
 	"github.com/spf13/cobra"
 )
 
@@ -38,19 +37,9 @@ func TestCli_Capacity(t *testing.T) {
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
 				root.SetArgs([]string{subCommand, "get"})
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				t.Cleanup(func() {
-					w.Close()
-					os.Stdout = rescueStdout
-				})
 
-				if err := root.Execute(); err != nil {
-					t.Fatal(err)
-				}
+				out := helper.ExecuteAndCaptureOutput(t, root)
 
-				out, _ := io.ReadAll(r)
 				if !strings.Contains(string(out[:]), "n3.xlarge.x86") &&
 					!strings.Contains(string(out[:]), "m3.large.x86") &&
 					!strings.Contains(string(out[:]), "s3.xlarge.x86") &&
@@ -71,19 +60,9 @@ func TestCli_Capacity(t *testing.T) {
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
 				root.SetArgs([]string{subCommand, "get", "-m", "-P", "c3.small.x86"})
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				t.Cleanup(func() {
-					w.Close()
-					os.Stdout = rescueStdout
-				})
 
-				if err := root.Execute(); err != nil {
-					t.Fatal(err)
-				}
+				out := helper.ExecuteAndCaptureOutput(t, root)
 
-				out, _ := io.ReadAll(r)
 				if !strings.Contains(string(out[:]), "c3.small.x86") &&
 					!strings.Contains(string(out[:]), "mt") &&
 					!strings.Contains(string(out[:]), "sv") &&
@@ -104,19 +83,9 @@ func TestCli_Capacity(t *testing.T) {
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
 				root.SetArgs([]string{subCommand, "get", "-m", "-P", "m3.large.x86"})
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				t.Cleanup(func() {
-					w.Close()
-					os.Stdout = rescueStdout
-				})
 
-				if err := root.Execute(); err != nil {
-					t.Fatal(err)
-				}
+				out := helper.ExecuteAndCaptureOutput(t, root)
 
-				out, _ := io.ReadAll(r)
 				if !strings.Contains(string(out[:]), "m3.large.x86") &&
 					!strings.Contains(string(out[:]), "mt") &&
 					!strings.Contains(string(out[:]), "sv") &&
@@ -136,19 +105,9 @@ func TestCli_Capacity(t *testing.T) {
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
 				root.SetArgs([]string{subCommand, "check", "-m", "ny,da", "-P", "c3.medium.x86", "-q", "10"})
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				t.Cleanup(func() {
-					w.Close()
-					os.Stdout = rescueStdout
-				})
 
-				if err := root.Execute(); err != nil {
-					t.Fatal(err)
-				}
+				out := helper.ExecuteAndCaptureOutput(t, root)
 
-				out, _ := io.ReadAll(r)
 				if !strings.Contains(string(out[:]), "c3.medium.x86") &&
 					!strings.Contains(string(out[:]), "ny") &&
 					!strings.Contains(string(out[:]), "da") {
@@ -166,19 +125,9 @@ func TestCli_Capacity(t *testing.T) {
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
 				root.SetArgs([]string{subCommand, "check", "-m", "da", "-P", "c3.medium.x86,m3.large.x86", "-q", "10"})
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				t.Cleanup(func() {
-					w.Close()
-					os.Stdout = rescueStdout
-				})
 
-				if err := root.Execute(); err != nil {
-					t.Fatal(err)
-				}
+				out := helper.ExecuteAndCaptureOutput(t, root)
 
-				out, _ := io.ReadAll(r)
 				if !strings.Contains(string(out[:]), "c3.medium.x86") &&
 					!strings.Contains(string(out[:]), "m3.large.x86") &&
 					!strings.Contains(string(out[:]), "ny") &&
@@ -197,19 +146,9 @@ func TestCli_Capacity(t *testing.T) {
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
 				root.SetArgs([]string{subCommand, "check", "-m", "ny,da", "-P", "c3.medium.x86,m3.large.x86", "-q", "10"})
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				t.Cleanup(func() {
-					w.Close()
-					os.Stdout = rescueStdout
-				})
 
-				if err := root.Execute(); err != nil {
-					t.Fatal(err)
-				}
+				out := helper.ExecuteAndCaptureOutput(t, root)
 
-				out, _ := io.ReadAll(r)
 				if !strings.Contains(string(out[:]), "c3.medium.x86") &&
 					!strings.Contains(string(out[:]), "m3.large.x86") &&
 					!strings.Contains(string(out[:]), "ny") &&

--- a/test/e2e/devices/devicecreateflagstest/device_create_flags_test.go
+++ b/test/e2e/devices/devicecreateflagstest/device_create_flags_test.go
@@ -1,8 +1,6 @@
 package devicecreateflagstest
 
 import (
-	"io"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -15,7 +13,7 @@ import (
 )
 
 func TestCli_Devices_Create_Flags(t *testing.T) {
-	var projectId, deviceId string
+	var deviceId string
 	var err error
 	subCommand := "device"
 	consumerToken := ""
@@ -42,59 +40,35 @@ func TestCli_Devices_Create_Flags(t *testing.T) {
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
 				projectName := "metal-cli-device-create-flags" + helper.GenerateRandomString(5)
-				projectId, err = helper.CreateTestProject(t, projectName)
-				t.Cleanup(func() {
-					if err := helper.CleanTestProject(t, projectId); err != nil &&
-						!strings.Contains(err.Error(), "Not Found") {
-						t.Error(err)
-					}
-				})
-				if err != nil {
-					t.Fatal(err)
+				project := helper.CreateTestProject(t, projectName)
+
+				root.SetArgs([]string{subCommand, "create", "-p", project.GetId(), "-P", "m3.small.x86", "-m", "da", "-H", "metal-cli-create-flags-dev", "--operating-system", "custom_ipxe", "--always-pxe=true", "--ipxe-script-url", "https://boot.netboot.xyz/"})
+
+				out := helper.ExecuteAndCaptureOutput(t, root)
+
+				if !strings.Contains(string(out[:]), "metal-cli-create-flags-dev") &&
+					!strings.Contains(string(out[:]), "Ubuntu 20.04 LTS") &&
+					!strings.Contains(string(out[:]), "queued") {
+					t.Error("expected output should include metal-cli-create-flags-dev, Ubuntu 20.04 LTS, and queued strings in the out string ")
 				}
+				name := "metal-cli-create-flags-dev"
+				idNamePattern := `(?m)^\| ([a-zA-Z0-9-]+) +\| *` + name + ` *\|`
 
-				if len(projectId) != 0 {
+				// Find the match of the ID and NAME pattern in the table string
+				match := regexp.MustCompile(idNamePattern).FindStringSubmatch(string(out[:]))
 
-					root.SetArgs([]string{subCommand, "create", "-p", projectId, "-P", "m3.small.x86", "-m", "da", "-H", "metal-cli-create-flags-dev", "--operating-system", "custom_ipxe", "--always-pxe=true", "--ipxe-script-url", "https://boot.netboot.xyz/"})
-					rescueStdout := os.Stdout
-					r, w, _ := os.Pipe()
-					os.Stdout = w
+				// Extract the ID from the match
+				if len(match) > 1 {
+					deviceId = strings.TrimSpace(match[1])
+					_, err = helper.IsDeviceStateActive(t, deviceId)
 					t.Cleanup(func() {
-						w.Close()
-						os.Stdout = rescueStdout
+						helper.CleanTestDevice(t, deviceId)
 					})
-
-					if err := root.Execute(); err != nil {
+					if err != nil {
 						t.Fatal(err)
 					}
-
-					out, _ := io.ReadAll(r)
-
-					if !strings.Contains(string(out[:]), "metal-cli-create-flags-dev") &&
-						!strings.Contains(string(out[:]), "Ubuntu 20.04 LTS") &&
-						!strings.Contains(string(out[:]), "queued") {
-						t.Error("expected output should include metal-cli-create-flags-dev, Ubuntu 20.04 LTS, and queued strings in the out string ")
-					}
-					name := "metal-cli-create-flags-dev"
-					idNamePattern := `(?m)^\| ([a-zA-Z0-9-]+) +\| *` + name + ` *\|`
-
-					// Find the match of the ID and NAME pattern in the table string
-					match := regexp.MustCompile(idNamePattern).FindStringSubmatch(string(out[:]))
-
-					// Extract the ID from the match
-					if len(match) > 1 {
-						deviceId = strings.TrimSpace(match[1])
-						_, err = helper.IsDeviceStateActive(t, deviceId)
-						t.Cleanup(func() {
-							if err := helper.CleanTestDevice(t, deviceId); err != nil &&
-								!strings.Contains(err.Error(), "Not Found") {
-								t.Error(err)
-							}
-						})
-						if err != nil {
-							t.Fatal(err)
-						}
-					}
+				} else {
+					t.Errorf("No match found for %v in %v", idNamePattern, string(out[:]))
 				}
 			},
 		},

--- a/test/e2e/devices/deviceupdatetest/device_update_test.go
+++ b/test/e2e/devices/deviceupdatetest/device_update_test.go
@@ -1,8 +1,6 @@
 package deviceupdatetest
 
 import (
-	"io"
-	"os"
 	"strings"
 	"testing"
 
@@ -14,8 +12,6 @@ import (
 )
 
 func TestCli_Devices_Update(t *testing.T) {
-	var projectId, deviceId string
-	var err error
 	subCommand := "device"
 	consumerToken := ""
 	apiURL := ""
@@ -41,47 +37,18 @@ func TestCli_Devices_Update(t *testing.T) {
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
 				projectName := "metal-cli-device-update" + helper.GenerateRandomString(5)
-				projectId, err = helper.CreateTestProject(t, projectName)
-				t.Cleanup(func() {
-					if err := helper.CleanTestProject(t, projectId); err != nil &&
-						!strings.Contains(err.Error(), "Not Found") {
-						t.Error(err)
-					}
-				})
+				project := helper.CreateTestProject(t, projectName)
+				device := helper.CreateTestDevice(t, project.GetId(), "metal-cli-update-dev")
+
+				status, err := helper.IsDeviceStateActive(t, device.GetId())
 				if err != nil {
 					t.Fatal(err)
 				}
+				if status == true {
+					root.SetArgs([]string{subCommand, "update", "-i", device.GetId(), "-H", "metal-cli-update-dev-test", "-d", "This device used for testing"})
 
-				deviceId, err = helper.CreateTestDevice(t, projectId, "metal-cli-update-dev")
-				t.Cleanup(func() {
-					if err := helper.CleanTestDevice(t, deviceId); err != nil &&
-						!strings.Contains(err.Error(), "Not Found") {
-						t.Error(err)
-					}
-				})
-				if err != nil {
-					t.Fatal(err)
-				}
+					out := helper.ExecuteAndCaptureOutput(t, root)
 
-				status, err := helper.IsDeviceStateActive(t, deviceId)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if len(projectId) != 0 && len(deviceId) != 0 && status == true {
-					root.SetArgs([]string{subCommand, "update", "-i", deviceId, "-H", "metal-cli-update-dev-test", "-d", "This device used for testing"})
-					rescueStdout := os.Stdout
-					r, w, _ := os.Pipe()
-					os.Stdout = w
-					t.Cleanup(func() {
-						w.Close()
-						os.Stdout = rescueStdout
-					})
-
-					if err := root.Execute(); err != nil {
-						t.Fatal(err)
-					}
-
-					out, _ := io.ReadAll(r)
 					if !strings.Contains(string(out[:]), "metal-cli-update-dev-test") {
 						t.Error("expected output should include metal-cli-update-dev-test in the out string ")
 					}

--- a/test/e2e/events/projecteventstest/project_events_test.go
+++ b/test/e2e/events/projecteventstest/project_events_test.go
@@ -1,8 +1,6 @@
 package eventsprojtest
 
 import (
-	"io"
-	"os"
 	"strings"
 	"testing"
 
@@ -14,8 +12,6 @@ import (
 )
 
 func TestCli_Events_Get(t *testing.T) {
-	var projectId string
-	var err error
 	subCommand := "event"
 	consumerToken := ""
 	apiURL := ""
@@ -42,30 +38,14 @@ func TestCli_Events_Get(t *testing.T) {
 				root := c.Root()
 
 				projectName := "metal-cli-projects-events" + helper.GenerateRandomString(5)
-				projectId, err = helper.CreateTestProject(t, projectName)
-				if err != nil {
-					t.Error(err)
-				}
-				root.SetArgs([]string{subCommand, "get", "-p", projectId})
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				t.Cleanup(func() {
-					w.Close()
-					os.Stdout = rescueStdout
-				})
+				project := helper.CreateTestProject(t, projectName)
 
-				if err := root.Execute(); err != nil {
-					t.Fatal(err)
-				}
+				root.SetArgs([]string{subCommand, "get", "-p", project.GetId()})
 
-				out, _ := io.ReadAll(r)
+				out := helper.ExecuteAndCaptureOutput(t, root)
+
 				if !strings.Contains(string(out[:]), "metal-cli-events-pro") {
 					t.Error("expected output should include metal-cli-events-pro in output string")
-				}
-				err = helper.CleanTestProject(t, projectId)
-				if err != nil {
-					t.Error(err)
 				}
 			},
 		},

--- a/test/e2e/metrotest/metro_test.go
+++ b/test/e2e/metrotest/metro_test.go
@@ -1,14 +1,13 @@
 package metrotest
 
 import (
-	"io"
-	"os"
 	"strings"
 	"testing"
 
 	root "github.com/equinix/metal-cli/internal/cli"
 	"github.com/equinix/metal-cli/internal/metros"
 	outputPkg "github.com/equinix/metal-cli/internal/outputs"
+	"github.com/equinix/metal-cli/test/helper"
 	"github.com/spf13/cobra"
 )
 
@@ -38,19 +37,9 @@ func TestCli_Metros(t *testing.T) {
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
 				root.SetArgs([]string{subCommand, "get"})
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				t.Cleanup(func() {
-					w.Close()
-					os.Stdout = rescueStdout
-				})
 
-				if err := root.Execute(); err != nil {
-					t.Fatal(err)
-				}
+				out := helper.ExecuteAndCaptureOutput(t, root)
 
-				out, _ := io.ReadAll(r)
 				if !strings.Contains(string(out[:]), "Seattle") &&
 					!strings.Contains(string(out[:]), "Tokyo") &&
 					!strings.Contains(string(out[:]), "Sydney") &&

--- a/test/e2e/ostest/os_test.go
+++ b/test/e2e/ostest/os_test.go
@@ -1,14 +1,13 @@
 package ostest
 
 import (
-	"io"
-	"os"
 	"strings"
 	"testing"
 
 	root "github.com/equinix/metal-cli/internal/cli"
 	metalos "github.com/equinix/metal-cli/internal/os"
 	outputPkg "github.com/equinix/metal-cli/internal/outputs"
+	"github.com/equinix/metal-cli/test/helper"
 	"github.com/spf13/cobra"
 )
 
@@ -38,19 +37,9 @@ func TestCli_OperatingSystem(t *testing.T) {
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
 				root.SetArgs([]string{subCommand, "get"})
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				t.Cleanup(func() {
-					w.Close()
-					os.Stdout = rescueStdout
-				})
 
-				if err := root.Execute(); err != nil {
-					t.Fatal(err)
-				}
+				out := helper.ExecuteAndCaptureOutput(t, root)
 
-				out, _ := io.ReadAll(r)
 				if !strings.Contains(string(out[:]), "RedHat Enterprise Linux 7") &&
 					!strings.Contains(string(out[:]), "RancherOS") &&
 					!strings.Contains(string(out[:]), "VMware ESXi 8.0") &&

--- a/test/e2e/plantest/plan_test.go
+++ b/test/e2e/plantest/plan_test.go
@@ -1,7 +1,6 @@
 package plantest
 
 import (
-	"io"
 	"os"
 	"strings"
 	"testing"
@@ -9,6 +8,7 @@ import (
 	root "github.com/equinix/metal-cli/internal/cli"
 	outputPkg "github.com/equinix/metal-cli/internal/outputs"
 	"github.com/equinix/metal-cli/internal/plans"
+	"github.com/equinix/metal-cli/test/helper"
 	"github.com/spf13/cobra"
 )
 
@@ -41,19 +41,9 @@ func TestCli_Plans(t *testing.T) {
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
 				root.SetArgs([]string{subCommand, "get"})
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				t.Cleanup(func() {
-					w.Close()
-					os.Stdout = rescueStdout
-				})
 
-				if err := root.Execute(); err != nil {
-					t.Fatal(err)
-				}
+				out := helper.ExecuteAndCaptureOutput(t, root)
 
-				out, _ := io.ReadAll(r)
 				if !strings.Contains(string(out[:]), "m3.small.x86") &&
 					!strings.Contains(string(out[:]), "m3.large.x86") &&
 					!strings.Contains(string(out[:]), "c3.medium.x86") &&
@@ -74,19 +64,9 @@ func TestCli_Plans(t *testing.T) {
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
 				root.SetArgs([]string{subCommand, "get", "--token", os.Getenv("METAL_AUTH_TOKEN"), "--filter", "slug=m3.small.x86"})
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				t.Cleanup(func() {
-					w.Close()
-					os.Stdout = rescueStdout
-				})
 
-				if err := root.Execute(); err != nil {
-					t.Fatal(err)
-				}
+				out := helper.ExecuteAndCaptureOutput(t, root)
 
-				out, _ := io.ReadAll(r)
 				if !strings.Contains(string(out[:]), "m3.small.x86") {
 					t.Error("expected output should include m3.small.x86 by SLUG")
 				}
@@ -102,20 +82,9 @@ func TestCli_Plans(t *testing.T) {
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
 				root.SetArgs([]string{subCommand, "get", "--token", os.Getenv("METAL_AUTH_TOKEN"), "--filter", "type=standard"})
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				os.Stdout = w
-				t.Cleanup(func() {
-					w.Close()
-					os.Stdout = rescueStdout
-				})
 
-				if err := root.Execute(); err != nil {
-					t.Fatal(err)
-				}
+				out := helper.ExecuteAndCaptureOutput(t, root)
 
-				out, _ := io.ReadAll(r)
 				if !strings.Contains(string(out[:]), "m3.small.x86") &&
 					!strings.Contains(string(out[:]), "m3.large.x86") &&
 					!strings.Contains(string(out[:]), "c3.medium.x86") &&

--- a/test/e2e/ports/convert_test.go
+++ b/test/e2e/ports/convert_test.go
@@ -1,8 +1,6 @@
 package ports
 
 import (
-	"io"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -17,22 +15,13 @@ import (
 )
 
 func TestPorts_Convert(t *testing.T) {
-	var projectId, deviceId string
 	subCommand := "port"
 	consumerToken := ""
 	apiURL := ""
 	Version := "devel"
 	rootClient := root.NewClient(consumerToken, apiURL, Version)
 
-	device := helper.SetupProjectAndDevice(t, &projectId, &deviceId, "metal-cli-port-convert")
-	t.Cleanup(func() {
-		if err := helper.CleanupProjectAndDevice(t, deviceId, projectId); err != nil {
-			t.Error(err)
-		}
-	})
-	if device == nil {
-		return
-	}
+	_, device := helper.SetupProjectAndDevice(t, "metal-cli-port-convert")
 
 	port := &device.GetNetworkPorts()[2]
 	if port == nil {
@@ -57,19 +46,7 @@ func TestPorts_Convert(t *testing.T) {
 
 				root.SetArgs([]string{subCommand, "convert", "-i", port.GetId(), "--layer2", "--bonded=false", "--force"})
 
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				t.Cleanup(func() {
-					w.Close()
-					os.Stdout = rescueStdout
-				})
-
-				if err := root.Execute(); err != nil {
-					t.Fatal(err)
-				}
-
-				out, _ := io.ReadAll(r)
+				out := helper.ExecuteAndCaptureOutput(t, root)
 
 				assertPortCmdOutput(t, port, string(out[:]), "layer2-individual", false)
 			},
@@ -83,19 +60,7 @@ func TestPorts_Convert(t *testing.T) {
 
 				root.SetArgs([]string{subCommand, "convert", "-i", port.GetId(), "--layer2", "--bonded", "--force"})
 
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				t.Cleanup(func() {
-					w.Close()
-					os.Stdout = rescueStdout
-				})
-
-				if err := root.Execute(); err != nil {
-					t.Fatal(err)
-				}
-
-				out, _ := io.ReadAll(r)
+				out := helper.ExecuteAndCaptureOutput(t, root)
 
 				assertPortCmdOutput(t, port, string(out[:]), "layer2-bonded", true)
 			},
@@ -109,19 +74,7 @@ func TestPorts_Convert(t *testing.T) {
 
 				root.SetArgs([]string{subCommand, "convert", "-i", port.GetId(), "-2=false", "--force"})
 
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				t.Cleanup(func() {
-					w.Close()
-					os.Stdout = rescueStdout
-				})
-
-				if err := root.Execute(); err != nil {
-					t.Fatal(err)
-				}
-
-				out, _ := io.ReadAll(r)
+				out := helper.ExecuteAndCaptureOutput(t, root)
 
 				assertPortCmdOutput(t, port, string(out[:]), "layer3", true)
 			},

--- a/test/e2e/sshtest/ssh_test.go
+++ b/test/e2e/sshtest/ssh_test.go
@@ -1,14 +1,13 @@
 package sshtest
 
 import (
-	"io"
-	"os"
 	"strings"
 	"testing"
 
 	root "github.com/equinix/metal-cli/internal/cli"
 	outputPkg "github.com/equinix/metal-cli/internal/outputs"
 	"github.com/equinix/metal-cli/internal/ssh"
+	"github.com/equinix/metal-cli/test/helper"
 	"github.com/spf13/cobra"
 )
 
@@ -38,19 +37,9 @@ func TestCli_SshKey(t *testing.T) {
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
 				root.SetArgs([]string{subCommand, "get"})
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				t.Cleanup(func() {
-					w.Close()
-					os.Stdout = rescueStdout
-				})
 
-				if err := root.Execute(); err != nil {
-					t.Fatal(err)
-				}
+				out := helper.ExecuteAndCaptureOutput(t, root)
 
-				out, _ := io.ReadAll(r)
 				if !strings.Contains(string(out[:]), "ID") &&
 					!strings.Contains(string(out[:]), "LABEL") &&
 					!strings.Contains(string(out[:]), "CREATED") {

--- a/test/e2e/usertest/user_test.go
+++ b/test/e2e/usertest/user_test.go
@@ -1,14 +1,13 @@
 package usertest
 
 import (
-	"io"
-	"os"
 	"strings"
 	"testing"
 
 	root "github.com/equinix/metal-cli/internal/cli"
 	outputPkg "github.com/equinix/metal-cli/internal/outputs"
 	"github.com/equinix/metal-cli/internal/users"
+	"github.com/equinix/metal-cli/test/helper"
 	"github.com/spf13/cobra"
 )
 
@@ -38,19 +37,9 @@ func TestCli_Users(t *testing.T) {
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
 				root.SetArgs([]string{subCommand, "get"})
-				rescueStdout := os.Stdout
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				t.Cleanup(func() {
-					w.Close()
-					os.Stdout = rescueStdout
-				})
 
-				if err := root.Execute(); err != nil {
-					t.Fatal(err)
-				}
+				out := helper.ExecuteAndCaptureOutput(t, root)
 
-				out, _ := io.ReadAll(r)
 				if !strings.Contains(string(out[:]), "ID") &&
 					!strings.Contains(string(out[:]), "FULL NAME") &&
 					!strings.Contains(string(out[:]), "EMAIL") &&

--- a/test/e2e/vlan/vlan_creat_test.go
+++ b/test/e2e/vlan/vlan_creat_test.go
@@ -1,8 +1,6 @@
 package vlan
 
 import (
-	"io"
-	"os"
 	"strings"
 	"testing"
 
@@ -14,7 +12,6 @@ import (
 )
 
 func TestCli_Vlan_Create(t *testing.T) {
-	var projectId string
 	var err error
 	subCommand := "vlan"
 	consumerToken := ""
@@ -41,36 +38,18 @@ func TestCli_Vlan_Create(t *testing.T) {
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
 				projectName := "metal-cli-vlan-create-pro" + helper.GenerateRandomString(5)
-				projectId, err = helper.CreateTestProject(t, projectName)
+				project := helper.CreateTestProject(t, projectName)
 				if err != nil {
 					t.Error(err)
 				}
-				if len(projectId) != 0 {
-					root.SetArgs([]string{subCommand, "create", "-p", projectId, "-m", "da", "--vxlan", "2023", "-d", "metal-cli-vlan-test"})
-					rescueStdout := os.Stdout
-					r, w, _ := os.Pipe()
-					os.Stdout = w
-					t.Cleanup(func() {
-						w.Close()
-						os.Stdout = rescueStdout
-					})
+				root.SetArgs([]string{subCommand, "create", "-p", project.GetId(), "-m", "da", "--vxlan", "2023", "-d", "metal-cli-vlan-test"})
 
-					if err := root.Execute(); err != nil {
-						t.Fatal(err)
-					}
+				out := helper.ExecuteAndCaptureOutput(t, root)
 
-					out, _ := io.ReadAll(r)
-
-					if !strings.Contains(string(out[:]), "metal-cli-vlan-test") &&
-						!strings.Contains(string(out[:]), "da") &&
-						!strings.Contains(string(out[:]), "2023") {
-						t.Error("expected output should include metal-cli-vlan-test, da and 2023 strings in the out string")
-					}
-
-					err = helper.CleanTestProject(t, projectId)
-					if err != nil {
-						t.Error(err)
-					}
+				if !strings.Contains(string(out[:]), "metal-cli-vlan-test") &&
+					!strings.Contains(string(out[:]), "da") &&
+					!strings.Contains(string(out[:]), "2023") {
+					t.Error("expected output should include metal-cli-vlan-test, da and 2023 strings in the out string")
 				}
 			},
 		},


### PR DESCRIPTION
A recent refactor of the test code introduced persistent timeouts, even in tests that do not perform API-intensive tasks (for example, read-only tests that request capacity information).

These timeouts were happening because the tests temporarily replace stdout with a byte buffer in order to capture command output for validation; during the most recent refactor, the code that closes the byte buffer and restores stdout was moved to a `t.Cleanup` handler, so the buffer was not closed until after the test finished, causing the test to hang until it timed out.

This moves the stdout-juggling code into a helper function to ensure that we are using the same logic across all tests.  The helper function logs any errors that happen while closing or reading the byte buffer, but does not fail the test for those errors; the tests themselves should fail if those errors impact the behavior under test.

Fixes #416.  Related to #343.

In addition, existing test helpers are refactored to more easily ensure that resources created with test helpers are automatically cleaned up after a test runs and to ensure that tests fail early if a test resource could not be created.  Test helpers for deleting resources now log the ID of the resource they are trying to delete so we can more easily triage issues with test cleanup.