### PR TITLE
chore: add User-Agent prefix to test helper client

### DIFF
--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -19,6 +19,7 @@ import (
 func TestClient() *metalv1.APIClient {
 	configuration := metalv1.NewConfiguration()
 	configuration.AddDefaultHeader("X-Auth-Token", os.Getenv("METAL_AUTH_TOKEN"))
+	configuration.UserAgent = fmt.Sprintf("metal-cli/test-helper %s", configuration.UserAgent)
 	// For debug purpose
 	// configuration.Debug = true
 	apiClient := metalv1.NewAPIClient(configuration)


### PR DESCRIPTION
Adding a different User-Agent for the test helper client will help us correctly identify traffic that was generated from running CLI commands as opposed to traffic that was generated by using the SDK directly.