### PR TITLE
chore: fix project events test

### DIFF
--- a/test/e2e/events/projecteventstest/project_events_test.go
+++ b/test/e2e/events/projecteventstest/project_events_test.go
@@ -44,8 +44,8 @@ func TestCli_Events_Get(t *testing.T) {
 
 				out := helper.ExecuteAndCaptureOutput(t, root)
 
-				if !strings.Contains(string(out[:]), "metal-cli-events-pro") {
-					t.Error("expected output should include metal-cli-events-pro in output string")
+				if !strings.Contains(string(out[:]), projectName) {
+					t.Errorf("expected output should include %v in output string", projectName)
 				}
 			},
 		},


### PR DESCRIPTION
We recently changed how metal-cli end-to-end test resources are named, but the project events test was not updated to align with that change.  This updates the test so that it is capable of passing.