### PR TITLE
chore: run CI with Go version from mod file

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,9 +25,10 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - uses: actions/setup-go@v5
+    - name: Set up Go
+      uses: actions/setup-go@v5
       with:
-        go-version: ${{ matrix.go }}
+        go-version-file: go.mod
     - run: mkdir -p ~/.config/equinix
     - run: touch ~/.config/equinix/metal.yaml
     - name: Build docs

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,14 +37,14 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: 'e2e-test'
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.19'
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
       with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
     - name: Get dependencies
       run: go mod download
     - name: Run end-to-end tests

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,10 +16,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.19
-      - uses: actions/checkout@v4
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version-file: go.mod
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.19'
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+        go-version-file: go.mod
     - name: Get dependencies
       run: go mod download
     - name: Build


### PR DESCRIPTION
Using the go.mod to drive Go version choice in CI makes it easier to upgrade to newer versions of Go.  Since this CLI is shipped as a binary and not meant to be used as a module, there's not much reason to do matrix testing on multiple versions of Go.

This was broken out of #461 because the E2E test workflow uses a `pull_request_target` trigger.  That trigger means that the workflow always uses the workflow configuration from the `main` branch, so it's impossible for the E2E workflow to pass on that PR because--if we don't merge this PR first--the workflow configuration has to be updated in order to run on a different version of Go.