### PR TITLE
chore: remove trailing slash from API base URL

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -46,7 +46,7 @@ var (
 const (
 	consumerToken  = "Equinix Metal CLI"
 	apiTokenEnvVar = "METAL_AUTH_TOKEN"
-	apiURL         = "https://api.equinix.com/metal/v1/"
+	apiURL         = "https://api.equinix.com/metal/v1"
 )
 
 // NewCli struct

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	ConsumerToken = ""
-	URL           = "https://api.equinix.com/metal/v1/"
+	URL           = "https://api.equinix.com/metal/v1"
 	Version       = "metal"
 )
 


### PR DESCRIPTION
The `packngo` SDK assumed that the base API URL did not end with a slash, but `equinix-sdk-go` assumes that it does (since it's generated from an OpenAPI spec, all API paths in `equinix-sdk-go` start with a slash).  A trailing slash on the base API URL doesn't cause problems for `equinix-sdk-go`, but it can cause confusion when triaging issues.

This removes the trailing slash from the 2 places where we are configuring the base API URL.  We can do this safely now because we no longer use `packngo`.  Alternatively, we could make the base API URL configuration optional; the API URL configured here is identical to [the default used by the `metalv1` package in `equinix-sdk-go`](https://github.com/equinix/equinix-sdk-go/blob/main/services/metalv1/configuration.go#L97), so we only really need to change the API URL for tests that use a mock API.  That change would be more extensive so I opted for the smallest change instead.