### PR TITLE
chore: convert to push-button release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,30 @@
-name: release
+name: Generate Next Release
 
 on:
-  push:
-    tags:
-    - '*'
+  workflow_dispatch:
 
 jobs:
-  goreleaser:
+  release:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      -
-        name: Run GoReleaser
+      - name: Release
+        id: semantic-release
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          semantic_version: 19.0.5
+          extra_plugins: |
+            conventional-changelog-conventionalcommits@4.6.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
         id: semantic-release
         uses: cycjimmy/semantic-release-action@v4
         with:
-          semantic_version: 19.0.5
+          semantic_version: 24.0.0
           extra_plugins: |
-            conventional-changelog-conventionalcommits@4.6.3
+            conventional-changelog-conventionalcommits@8.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
           args: release --clean
+          version: '~> v2'
         env:
           # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 # This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
+version: 2
+
 before:
   hooks:
     # You may remove this if you don't use go modules.
@@ -48,6 +50,6 @@ brews:
     test: |
       system "#{bin}/metal -v"
     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
-    tap:
+    repository:
       owner: equinix
       name: homebrew-tap

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,45 +7,39 @@ before:
     # you may remove this if you don't need go generate
     - go generate ./...
 builds:
-- main: ./cmd/metal
-  env:
-  - CGO_ENABLED=0
-  binary: metal
-  ldflags:
-   - -X github.com/equinix/metal-cli/cmd.Version={{.Version}}
-   - -X github.com/equinix/metal-cli/cmd.Build=${.Commit}"
+  - main: ./cmd/metal
+    env:
+      - CGO_ENABLED=0
+    binary: metal
+    ldflags:
+      - -X github.com/equinix/metal-cli/cmd.Version={{.Version}}
+      - -X github.com/equinix/metal-cli/cmd.Build=${.Commit}"
 
-  goos:
-    - freebsd
-    - linux
-    - windows
-    - darwin
-  goarch:
-    - amd64
-    - arm
-    - arm64
-  goarm:
-    - "6"
-    - "7"
+    goos:
+      - freebsd
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - "6"
+      - "7"
 
 archives:
-- format: binary
-  name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+  - format: binary
+    name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
 release:
-  name_template: "{{.ProjectName}}-v{{.Version}}"
+  mode: "keep-existing"
 snapshot:
   name_template: "{{ .Tag }}-next"
-changelog:
-  sort: asc
-  filters:
-    exclude:
-    - '^docs:'
-    - '^test:'
 
-brews: 
-  - homepage: "https://metal.equinix.com/developers/docs/libraries/cli/"
+brews:
+  - homepage: "https://deploy.equinix.com/developers/docs/metal/libraries/cli/"
     description: "Official Equinix Metal CLI"
     license: "MIT"
     dependencies:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,28 @@
+{
+    "branches": [
+        "main"
+    ],
+    "ci": false,
+    "plugins": [
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                "preset": "conventionalcommits"
+            }
+        ],
+        [
+            "@semantic-release/release-notes-generator",
+            {
+                "preset": "conventionalcommits"
+            }
+        ],
+        [
+            "@semantic-release/github",
+            {
+                "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} :tada:",
+                "labels": false,
+                "releasedLabels": false
+            }
+        ]
+    ]
+}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,26 +4,21 @@ These build and release instructions are intended for the maintainers and future
 
 ## Preparing a new version
 
-There are no preperation steps.
+There are no preparation steps.
 
-* the version is computed from git tags
-* The changelog is generated from git and lives outside of git
-
-## Tagging
-
-Pull the latest `master` branch and locally `git tag -s 0.0.9`.
-
-When breaking changes are introduced bump the minor or major accordingly, restting the patch version.
+* the version is computed from [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) tags
+* There is no changelog; the GitHub release notes are generated based on [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) tags 
 
 ## Releasing
 
-Push the tag to GitHub and [GitHub Workflows](.github/workflows/release.yml) and [GoReleaser](.goreleaser.yml) will do the rest.
+Run the GitHub Actions [Release Workflow](.github/workflows/release.yml) on the `main` branch.
 
-```sh
-git push origin --tags 0.0.9
-```
+The release workflow:
+- Uses [Semantic Release](.releaserc.json) to determine the next version number and create the GitHub release
+- Uses [GoReleaser](.goreleaser.yml) to build the CLI binaries and attach them to the GitHub release
+- Updates the Homebrew tap
 
 This will build and release binaries for several different OS and Architecture combinations.
 
-Any special instructions or notes should be added by editing the release notes that goreleaser publishes. These notes can be found at https://github.com/equinix/metal-cli/releases
+Any special instructions or notes should be added by editing the release notes that the workflow publishes. These notes can be found at https://github.com/equinix/metal-cli/releases
 


### PR DESCRIPTION
This updates the existing release workflow so that it is run by pushing a button in the GitHub UI rather than creating a tag locally and pushing that tag up to GitHub.

The push-button workflow looks up the previous release and uses Conventional Commit tags to determine the correct next version for the new release.  As before, it uses GoReleaser to build the CLI and upload the binaries to the GitHub release.

I have confirmed on my fork that this works up through the GoReleaser step.

Closes #364 