### PR TITLE
chore: update contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Available via [https://github.com/equinix/metal-cli/blob/master/.github/CODE_OF_
 Please submit change requests and / or features via [Issues](https://github.com/equinix/metal-cli/issues). There's no guarantee it'll be changed, but you never know until you try. We'll try to add comments as soon as possible, though.
 
 #### Pull Requests
-All command changes must be reflected in the documentation, this includes new commands and changes to options. The documentation is generated via `make generate-docs`.
+All command changes must be reflected in the documentation, this includes new commands and changes to options. To generate the updated documentation, first run `make generate-docs` and confirm that your documentation changes render correctly. Then if it looks good, proceed to run `git` for the Pull Request.
 
 ### How to Report a Bug
 Bugs are problems in code, in the functionality of an application or in its UI design; you can submit them through [Issues](https://github.com/equinix/metal-cli/issues) as well.


### PR DESCRIPTION
Made the `make generate-docs` directions a bit clearer for contributors