### PR TITLE
fix: "device update --locked" should also unlock

### DIFF
--- a/docs/metal_device_update.md
+++ b/docs/metal_device_update.md
@@ -27,7 +27,7 @@ metal device update -i <device_id> [-H <hostname>] [-d <description>] [--locked=
   -H, --hostname string          The new hostname of the device.
   -i, --id string                The UUID of the device.
   -s, --ipxe-script-url string   Add or update the URL of the iPXE script.
-  -l, --locked bools             Locks or unlocks the device for future changes (<true|false>). (default [])
+  -l, --locked                   Locks or unlocks the device for future changes (<true|false>).
   -t, --tags strings             Adds or updates the tags for the device --tags="tag1,tag2".
   -u, --userdata string          Adds or updates the userdata for the device.
       --userdata-file string     Path to a userdata file for device initialization. Can not be used with --userdata.

--- a/docs/metal_device_update.md
+++ b/docs/metal_device_update.md
@@ -27,7 +27,7 @@ metal device update -i <device_id> [-H <hostname>] [-d <description>] [--locked 
   -H, --hostname string          The new hostname of the device.
   -i, --id string                The UUID of the device.
   -s, --ipxe-script-url string   Add or update the URL of the iPXE script.
-  -l, --locked                   Locks or unlocks the device for future changes (<true|false>).
+  -l, --locked bools             Locks or unlocks the device for future changes (<true|false>). (default [])
   -t, --tags strings             Adds or updates the tags for the device --tags="tag1,tag2".
   -u, --userdata string          Adds or updates the userdata for the device.
       --userdata-file string     Path to a userdata file for device initialization. Can not be used with --userdata.

--- a/docs/metal_device_update.md
+++ b/docs/metal_device_update.md
@@ -7,7 +7,7 @@ Updates a device.
 Updates the hostname of a device. Updates or adds a description, tags, userdata, custom data, and iPXE settings for an already provisioned device. Can also lock or unlock future changes to the device.
 
 ```
-metal device update -i <device_id> [-H <hostname>] [-d <description>] [--locked <boolean>] [-t <tags>] [-u <userdata> | --userdata-file <filepath>] [-c <customdata>] [-s <ipxe_script_url>] [--always-pxe=<true|false>] [flags]
+metal device update -i <device_id> [-H <hostname>] [-d <description>] [--locked=<true|false>] [-t <tags>] [-u <userdata> | --userdata-file <filepath>] [-c <customdata>] [-s <ipxe_script_url>] [--always-pxe=<true|false>] [flags]
 ```
 
 ### Examples

--- a/internal/devices/update.go
+++ b/internal/devices/update.go
@@ -45,7 +45,7 @@ func (c *Client) Update() *cobra.Command {
 	)
 	// updateDeviceCmd represents the updateDevice command
 	updateDeviceCmd := &cobra.Command{
-		Use:   `update -i <device_id> [-H <hostname>] [-d <description>] [--locked <boolean>] [-t <tags>] [-u <userdata> | --userdata-file <filepath>] [-c <customdata>] [-s <ipxe_script_url>] [--always-pxe=<true|false>]`,
+		Use:   `update -i <device_id> [-H <hostname>] [-d <description>] [--locked=<true|false>] [-t <tags>] [-u <userdata> | --userdata-file <filepath>] [-c <customdata>] [-s <ipxe_script_url>] [--always-pxe=<true|false>]`,
 		Short: "Updates a device.",
 		Long:  "Updates the hostname of a device. Updates or adds a description, tags, userdata, custom data, and iPXE settings for an already provisioned device. Can also lock or unlock future changes to the device.",
 		Example: `  # Updates the hostname of a device:

--- a/internal/devices/update.go
+++ b/internal/devices/update.go
@@ -76,14 +76,11 @@ func (c *Client) Update() *cobra.Command {
 			}
 
 			if cmd.Flag("locked").Changed {
-				locked, err := cmd.Flags().GetBoolSlice("locked")
+				locked, err := cmd.Flags().GetBool("locked")
 				if err != nil {
 					return fmt.Errorf("could not parse locked value: %w", err)
 				}
-				if len(locked) > 1 {
-					return fmt.Errorf("parameter locked may only be set once")
-				}
-				deviceUpdate.Locked = &locked[0]
+				deviceUpdate.Locked = &locked
 			}
 
 			if len(tags) > 0 {
@@ -125,7 +122,7 @@ func (c *Client) Update() *cobra.Command {
 	updateDeviceCmd.Flags().StringVarP(&description, "description", "d", "", "Adds or updates the description for the device.")
 	updateDeviceCmd.Flags().StringVarP(&userdata, "userdata", "u", "", "Adds or updates the userdata for the device.")
 	updateDeviceCmd.Flags().StringVarP(&userdataFile, "userdata-file", "", "", "Path to a userdata file for device initialization. Can not be used with --userdata.")
-	updateDeviceCmd.Flags().BoolSliceP("locked", "l", []bool{}, "Locks or unlocks the device for future changes (<true|false>).")
+	updateDeviceCmd.Flags().BoolP("locked", "l", false, "Locks or unlocks the device for future changes (<true|false>).")
 	updateDeviceCmd.Flags().StringSliceVarP(&tags, "tags", "t", []string{}, `Adds or updates the tags for the device --tags="tag1,tag2".`)
 	updateDeviceCmd.Flags().BoolVarP(&alwaysPXE, "always-pxe", "a", false, "Updates the always_pxe toggle for the device (<true|false>).")
 	updateDeviceCmd.Flags().StringVarP(&ipxescripturl, "ipxe-script-url", "s", "", "Add or update the URL of the iPXE script.")

--- a/internal/devices/update.go
+++ b/internal/devices/update.go
@@ -34,7 +34,6 @@ import (
 func (c *Client) Update() *cobra.Command {
 	var (
 		description   string
-		locked        bool
 		userdata      string
 		userdataFile  string
 		hostname      string
@@ -80,8 +79,15 @@ func (c *Client) Update() *cobra.Command {
 				deviceUpdate.Userdata = &userdata
 			}
 
-			if locked {
-				deviceUpdate.Locked = &locked
+			if cmd.Flag("locked").Changed {
+				locked, err := cmd.Flags().GetBoolSlice("locked")
+				if err != nil {
+					return fmt.Errorf("could not parse locked value: %w", err)
+				}
+				if len(locked) > 1 {
+					return fmt.Errorf("parameter locked may only be set once")
+				}
+				deviceUpdate.Locked = &locked[0]
 			}
 
 			if len(tags) > 0 {
@@ -123,12 +129,11 @@ func (c *Client) Update() *cobra.Command {
 	updateDeviceCmd.Flags().StringVarP(&description, "description", "d", "", "Adds or updates the description for the device.")
 	updateDeviceCmd.Flags().StringVarP(&userdata, "userdata", "u", "", "Adds or updates the userdata for the device.")
 	updateDeviceCmd.Flags().StringVarP(&userdataFile, "userdata-file", "", "", "Path to a userdata file for device initialization. Can not be used with --userdata.")
-	updateDeviceCmd.Flags().BoolVarP(&locked, "locked", "l", false, "Locks or unlocks the device for future changes (<true|false>).")
+	updateDeviceCmd.Flags().BoolSliceP("locked", "l", []bool{}, "Locks or unlocks the device for future changes (<true|false>).")
 	updateDeviceCmd.Flags().StringSliceVarP(&tags, "tags", "t", []string{}, `Adds or updates the tags for the device --tags="tag1,tag2".`)
 	updateDeviceCmd.Flags().BoolVarP(&alwaysPXE, "always-pxe", "a", false, "Updates the always_pxe toggle for the device (<true|false>).")
 	updateDeviceCmd.Flags().StringVarP(&ipxescripturl, "ipxe-script-url", "s", "", "Add or update the URL of the iPXE script.")
 	updateDeviceCmd.Flags().StringVarP(&customdata, "customdata", "c", "", "Adds or updates custom data to be included with your device's metadata.")
 	_ = updateDeviceCmd.MarkFlagRequired("id")
-
 	return updateDeviceCmd
 }

--- a/internal/devices/update.go
+++ b/internal/devices/update.go
@@ -63,10 +63,6 @@ func (c *Client) Update() *cobra.Command {
 				deviceUpdate.Description = &description
 			}
 
-			if userdata != "" && userdataFile != "" {
-				return fmt.Errorf("either userdata or userdata-file should be set")
-			}
-
 			if userdataFile != "" {
 				userdataRaw, readErr := os.ReadFile(userdataFile)
 				if readErr != nil {
@@ -135,5 +131,7 @@ func (c *Client) Update() *cobra.Command {
 	updateDeviceCmd.Flags().StringVarP(&ipxescripturl, "ipxe-script-url", "s", "", "Add or update the URL of the iPXE script.")
 	updateDeviceCmd.Flags().StringVarP(&customdata, "customdata", "c", "", "Adds or updates custom data to be included with your device's metadata.")
 	_ = updateDeviceCmd.MarkFlagRequired("id")
+	updateDeviceCmd.MarkFlagsMutuallyExclusive("userdata", "userdata-file")
+	updateDeviceCmd.Args = cobra.NoArgs
 	return updateDeviceCmd
 }

--- a/test/e2e/devices/deviceupdatetest/device_update_test.go
+++ b/test/e2e/devices/deviceupdatetest/device_update_test.go
@@ -42,7 +42,7 @@ func TestCli_Devices_Update(t *testing.T) {
 					t.Fatal(err)
 				}
 				if status == true {
-					root.SetArgs([]string{subCommand, "update", "-i", device.GetId(), "-H", "metal-cli-update-dev-test", "-d", "This device used for testing"})
+					root.SetArgs([]string{subCommand, "update", "-i", device.GetId(), "-H", "metal-cli-update-dev-test", "-d", "This device used for testing", "--locked=true"})
 
 					out := helper.ExecuteAndCaptureOutput(t, root)
 
@@ -50,6 +50,23 @@ func TestCli_Devices_Update(t *testing.T) {
 						t.Error("expected output should include metal-cli-update-dev-test in the out string ")
 					}
 				}
+
+				root.SetArgs([]string{subCommand, "delete", "-i", device.GetId()})
+
+				out := helper.ExecuteAndCaptureOutput(t, root)
+
+				if !strings.Contains(string(out[:]), "not delete") {
+					t.Error("expected output should include 'not delete' in the out string due to device locking")
+				}
+
+				root.SetArgs([]string{subCommand, "update", "-i", device.GetId(), "--locked=false"})
+
+				out = helper.ExecuteAndCaptureOutput(t, root)
+
+				if !strings.Contains(string(out[:]), "metal-cli-update-dev-test") {
+					t.Error("expected output should include metal-cli-update-dev-test in the out string ")
+				}
+
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #484 

Previous behavior was to set `{"locked":true}` in `PUT` requests whenever `--locked` was specified. This is because the presence of the flag itself is treated as a toggle. The value argument was ignored unless given as `--locked=true` or `--locked=false`. When `--locked=false` was given, the `PUT` request was `{}`, since the code required true values to add the field to the update request.

This change technically breaks the current ability to do `metal device update --locked --some-other-arg`. 

```console
$ PACKNGO_DEBUG=1 go run ./cmd/metal device update --locked false --locked true --id 1234
Error: parameter locked may only be set once
```

```console
$ PACKNGO_DEBUG=1 go run ./cmd/metal device update --locked --id 1234                    
Error: invalid argument "--id" for "-l, --locked" flag: strconv.ParseBool: parsing "--id": invalid syntax
...
```

```console
$ PACKNGO_DEBUG=1 go run ./cmd/metal device update --locked true  --id 1234              
PUT /metal/v1//devices/1234 HTTP/1.1
...
{"locked":true}
```

```console
$ PACKNGO_DEBUG=1 go run ./cmd/metal device update --locked false  --id 1234
PUT /metal/v1//devices/1234 HTTP/1.1
...
{"locked":false}
```
